### PR TITLE
Project files improvement and more target-frameworks

### DIFF
--- a/src/NaCl.Core.Benchmarks/ChaCha20Benchmark.cs
+++ b/src/NaCl.Core.Benchmarks/ChaCha20Benchmark.cs
@@ -1,4 +1,4 @@
-namespace NaCl.Core.Benchmarks
+﻿namespace NaCl.Core.Benchmarks
 {
     using System;
     using System.Collections.Generic;
@@ -10,7 +10,6 @@ namespace NaCl.Core.Benchmarks
     using BenchmarkDotNet.Attributes;
 
     [BenchmarkCategory("Stream Cipher")]
-    [CoreJob(baseline: true), ClrJob/*, MonoJob*/]
     [MemoryDiagnoser]
     [RPlotExporter, RankColumn]
     public class ChaCha20Benchmark

--- a/src/NaCl.Core.Benchmarks/ChaCha20Poly1305Benchmark.cs
+++ b/src/NaCl.Core.Benchmarks/ChaCha20Poly1305Benchmark.cs
@@ -9,7 +9,6 @@
     using BenchmarkDotNet.Attributes;
 
     [BenchmarkCategory("AEAD")]
-    [CoreJob(baseline: true), ClrJob/*, MonoJob*/]
     [MemoryDiagnoser]
     [RPlotExporter, RankColumn]
     public class ChaCha20Poly1305Benchmark

--- a/src/NaCl.Core.Benchmarks/NaCl.Core.Benchmarks.csproj
+++ b/src/NaCl.Core.Benchmarks/NaCl.Core.Benchmarks.csproj
@@ -2,16 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix'">net47;netcoreapp2.0</TargetFrameworks>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NaCl.Core.Benchmarks/Poly1305Benchmark.cs
+++ b/src/NaCl.Core.Benchmarks/Poly1305Benchmark.cs
@@ -5,7 +5,6 @@
     using BenchmarkDotNet.Attributes;
 
     [BenchmarkCategory("MAC")]
-    [CoreJob(baseline: true), ClrJob/*, MonoJob*/]
     [MemoryDiagnoser]
     [RPlotExporter, RankColumn]
     public class Poly1305Benchmark

--- a/src/NaCl.Core.Benchmarks/XChaCha20Benchmark.cs
+++ b/src/NaCl.Core.Benchmarks/XChaCha20Benchmark.cs
@@ -10,7 +10,6 @@
     using BenchmarkDotNet.Attributes;
 
     [BenchmarkCategory("Stream Cipher")]
-    [CoreJob(baseline: true), ClrJob/*, MonoJob*/]
     [MemoryDiagnoser]
     [RPlotExporter, RankColumn]
     public class XChaCha20Benchmark

--- a/src/NaCl.Core.Benchmarks/XChaCha20Poly1305Benchmark.cs
+++ b/src/NaCl.Core.Benchmarks/XChaCha20Poly1305Benchmark.cs
@@ -9,7 +9,6 @@
     using BenchmarkDotNet.Attributes;
 
     [BenchmarkCategory("AEAD")]
-    [CoreJob(baseline: true), ClrJob/*, MonoJob*/]
     [MemoryDiagnoser]
     [RPlotExporter, RankColumn]
     public class XChaCha20Poly1305Benchmark

--- a/src/NaCl.Core.Tests/NaCl.Core.Tests.csproj
+++ b/src/NaCl.Core.Tests/NaCl.Core.Tests.csproj
@@ -24,5 +24,9 @@
   <ItemGroup>
     <ProjectReference Include="..\NaCl.Core\NaCl.Core.csproj" />
   </ItemGroup>
-  
+
+  <Target Name="LogDebugInfo">
+    <Message Text="Building for $(TargetFramework) on $(OS)" Importance="High" />
+  </Target>
+
 </Project>

--- a/src/NaCl.Core.Tests/NaCl.Core.Tests.csproj
+++ b/src/NaCl.Core.Tests/NaCl.Core.Tests.csproj
@@ -1,45 +1,28 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix'">net47;netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <Version>1.0.0</Version>
-    <Authors>David De Smet</Authors>
-    <Copyright>Copyright © 2018 David De Smet</Copyright>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageTags>NaCl cryptography dotnet dotnet-core netstandard</PackageTags>
-    <PackageProjectUrl>https://github.com/idaviddesmet/NaCl.Core</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\NaCl.Core\NaCl.Core.csproj" />
   </ItemGroup>
-
-  <Target Name="LogDebugInfo">
-    <Message Text="Building for $(TargetFramework) on $(OS)" Importance="High" />
-  </Target>
-
+  
 </Project>

--- a/src/NaCl.Core/Base/ChaCha20Base.cs
+++ b/src/NaCl.Core/Base/ChaCha20Base.cs
@@ -136,77 +136,77 @@
                 {
                     // Column quarter rounds
                     x0 += x4;
-                    x12 = RotateLeft(x12 ^ x0, 16);
+                    x12 = BitUtils.RotateLeft(x12 ^ x0, 16);
                     x8 += x12;
-                    x4 = RotateLeft(x4 ^ x8, 12);
+                    x4 = BitUtils.RotateLeft(x4 ^ x8, 12);
                     x0 += x4;
-                    x12 = RotateLeft(x12 ^ x0, 8);
+                    x12 = BitUtils.RotateLeft(x12 ^ x0, 8);
                     x8 += x12;
-                    x4 = RotateLeft(x4 ^ x8, 7);
+                    x4 = BitUtils.RotateLeft(x4 ^ x8, 7);
 
                     x1 += x5;
-                    x13 = RotateLeft(x13 ^ x1, 16);
+                    x13 = BitUtils.RotateLeft(x13 ^ x1, 16);
                     x9 += x13;
-                    x5 = RotateLeft(x5 ^ x9, 12);
+                    x5 = BitUtils.RotateLeft(x5 ^ x9, 12);
                     x1 += x5;
-                    x13 = RotateLeft(x13 ^ x1, 8);
+                    x13 = BitUtils.RotateLeft(x13 ^ x1, 8);
                     x9 += x13;
-                    x5 = RotateLeft(x5 ^ x9, 7);
+                    x5 = BitUtils.RotateLeft(x5 ^ x9, 7);
 
                     x2 += x6;
-                    x14 = RotateLeft(x14 ^ x2, 16);
+                    x14 = BitUtils.RotateLeft(x14 ^ x2, 16);
                     x10 += x14;
-                    x6 = RotateLeft(x6 ^ x10, 12);
+                    x6 = BitUtils.RotateLeft(x6 ^ x10, 12);
                     x2 += x6;
-                    x14 = RotateLeft(x14 ^ x2, 8);
+                    x14 = BitUtils.RotateLeft(x14 ^ x2, 8);
                     x10 += x14;
-                    x6 = RotateLeft(x6 ^ x10, 7);
+                    x6 = BitUtils.RotateLeft(x6 ^ x10, 7);
 
                     x3 += x7;
-                    x15 = RotateLeft(x15 ^ x3, 16);
+                    x15 = BitUtils.RotateLeft(x15 ^ x3, 16);
                     x11 += x15;
-                    x7 = RotateLeft(x7 ^ x11, 12);
+                    x7 = BitUtils.RotateLeft(x7 ^ x11, 12);
                     x3 += x7;
-                    x15 = RotateLeft(x15 ^ x3, 8);
+                    x15 = BitUtils.RotateLeft(x15 ^ x3, 8);
                     x11 += x15;
-                    x7 = RotateLeft(x7 ^ x11, 7);
+                    x7 = BitUtils.RotateLeft(x7 ^ x11, 7);
 
                     // Diagonal quarter rounds
                     x0 += x5;
-                    x15 = RotateLeft(x15 ^ x0, 16);
+                    x15 = BitUtils.RotateLeft(x15 ^ x0, 16);
                     x10 += x15;
-                    x5 = RotateLeft(x5 ^ x10, 12);
+                    x5 = BitUtils.RotateLeft(x5 ^ x10, 12);
                     x0 += x5;
-                    x15 = RotateLeft(x15 ^ x0, 8);
+                    x15 = BitUtils.RotateLeft(x15 ^ x0, 8);
                     x10 += x15;
-                    x5 = RotateLeft(x5 ^ x10, 7);
+                    x5 = BitUtils.RotateLeft(x5 ^ x10, 7);
 
                     x1 += x6;
-                    x12 = RotateLeft(x12 ^ x1, 16);
+                    x12 = BitUtils.RotateLeft(x12 ^ x1, 16);
                     x11 += x12;
-                    x6 = RotateLeft(x6 ^ x11, 12);
+                    x6 = BitUtils.RotateLeft(x6 ^ x11, 12);
                     x1 += x6;
-                    x12 = RotateLeft(x12 ^ x1, 8);
+                    x12 = BitUtils.RotateLeft(x12 ^ x1, 8);
                     x11 += x12;
-                    x6 = RotateLeft(x6 ^ x11, 7);
+                    x6 = BitUtils.RotateLeft(x6 ^ x11, 7);
 
                     x2 += x7;
-                    x13 = RotateLeft(x13 ^ x2, 16);
+                    x13 = BitUtils.RotateLeft(x13 ^ x2, 16);
                     x8 += x13;
-                    x7 = RotateLeft(x7 ^ x8, 12);
+                    x7 = BitUtils.RotateLeft(x7 ^ x8, 12);
                     x2 += x7;
-                    x13 = RotateLeft(x13 ^ x2, 8);
+                    x13 = BitUtils.RotateLeft(x13 ^ x2, 8);
                     x8 += x13;
-                    x7 = RotateLeft(x7 ^ x8, 7);
+                    x7 = BitUtils.RotateLeft(x7 ^ x8, 7);
 
                     x3 += x4;
-                    x14 = RotateLeft(x14 ^ x3, 16);
+                    x14 = BitUtils.RotateLeft(x14 ^ x3, 16);
                     x9 += x14;
-                    x4 = RotateLeft(x4 ^ x9, 12);
+                    x4 = BitUtils.RotateLeft(x4 ^ x9, 12);
                     x3 += x4;
-                    x14 = RotateLeft(x14 ^ x3, 8);
+                    x14 = BitUtils.RotateLeft(x14 ^ x3, 8);
                     x9 += x14;
-                    x4 = RotateLeft(x4 ^ x9, 7);
+                    x4 = BitUtils.RotateLeft(x4 ^ x9, 7);
                 }
             }
 
@@ -246,13 +246,13 @@
         public static void QuarterRound(ref uint a, ref uint b, ref uint c, ref uint d)
         {
             a += b;
-            d = RotateLeft(d ^ a, 16);
+            d = BitUtils.RotateLeft(d ^ a, 16);
             c += d;
-            b = RotateLeft(b ^ c, 12);
+            b = BitUtils.RotateLeft(b ^ c, 12);
             a += b;
-            d = RotateLeft(d ^ a, 8);
+            d = BitUtils.RotateLeft(d ^ a, 8);
             c += d;
-            b = RotateLeft(b ^ c, 7);
+            b = BitUtils.RotateLeft(b ^ c, 7);
         }
 
         protected static void SetSigma(ref Array16<uint> state)

--- a/src/NaCl.Core/Base/Snuffle.cs
+++ b/src/NaCl.Core/Base/Snuffle.cs
@@ -209,8 +209,6 @@
             }
         }
 
-        protected static uint RotateLeft(uint x, int y) => (x << y) | (x >> (32 - y));
-
         /// <summary>
         /// Formats the nonce length exception message.
         /// </summary>

--- a/src/NaCl.Core/Internal/BitUtils.cs
+++ b/src/NaCl.Core/Internal/BitUtils.cs
@@ -1,0 +1,27 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace NaCl.Core.Internal
+{
+    internal static class BitUtils
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint RotateLeft(uint value, int offset)
+        {
+#if FCL_BITOPS
+            return System.Numerics.BitOperations.RotateLeft(value, offset);
+#else
+            return (value << offset) | (value >> (32 - offset));
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong RotateLeft(ulong value, int offset) // Taken help from: https://stackoverflow.com/a/48580489/5592276
+        {
+#if FCL_BITOPS
+            return System.Numerics.BitOperations.RotateLeft(value, offset);
+#else
+            return (value << offset) | (value >> (64 - offset));
+#endif
+        }
+    }
+}

--- a/src/NaCl.Core/NaCl.Core.csproj
+++ b/src/NaCl.Core/NaCl.Core.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
+  <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
+    <DefineConstants>FCL_BITOPS</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/src/NaCl.Core/NaCl.Core.csproj
+++ b/src/NaCl.Core/NaCl.Core.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp3.1;net45;net48</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp3.1;net45;net48</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <Version>1.2.0</Version>
@@ -24,5 +25,9 @@
   <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
     <DefineConstants>FCL_BITOPS</DefineConstants>
   </PropertyGroup>
+
+  <Target Name="LogDebugInfo">
+    <Message Text="Building for $(TargetFramework) on $(OS)" Importance="High" />
+  </Target>
 
 </Project>

--- a/src/NaCl.Core/NaCl.Core.csproj
+++ b/src/NaCl.Core/NaCl.Core.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix'">net45;net47;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp3.1;net45;net48</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
     <Version>1.2.0</Version>
     <Authors>David De Smet</Authors>
     <Company />
@@ -16,20 +17,7 @@
     <RepositoryBranch>master</RepositoryBranch>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <Target Name="LogDebugInfo">
-    <Message Text="Building for $(TargetFramework) on $(OS)" Importance="High" />
-  </Target>
-
-  <ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) != 'netcoreapp3.1' AND $(TargetFramework) != 'netstandard2.1'">
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi,

This PR contains the following changes:
- Improvement and simplification of projects files
- Updating NuGet package references to the latest available
- Support for .NET Framework 4.8
- Support for .NET Standard 2.1
- Using [`BitOperations`](https://docs.microsoft.com/en-us/dotnet/api/system.numerics.bitoperations?view=netcore-3.1) class for .NET Core 3.1 ([The explanation](https://github.com/uranium62/xxHash/commit/7b907932cd9921e150dad210e80a199d1cfcf384))

These changes are not what I supposed to make but I have to commit that I may not be able to solve the two issues #40 and #41 at all due to my lack of knowledge of the NaCl itself, sorry for that.

Regards.