### PR TITLE
feat: ShuffleState and QuarterRound AVX2 and SSE3 and ARM AdvSIMD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,12 @@ jobs:
     steps:
     - name: 'Checkout'
       uses: actions/checkout@v4
-    - name: 'Download Artifact'
+    - name: 'Download All Artifacts'
       uses: actions/download-artifact@v4
       with:
-        name: 'ubuntu-latest'
+        path: ./artifacts
+        pattern: '*-latest'
+        merge-multiple: false
     - name: 'Install .NET SDK'
       uses: actions/setup-dotnet@v4
       with:
@@ -93,14 +95,15 @@ jobs:
           6.0.x
           8.0.x
           9.0.x
+          10.0.x
     - name: 'Install ReportGenerator'
       run: dotnet tool install -g dotnet-reportgenerator-globaltool
-    - name: 'Generate Coverage Report'
-      run: reportgenerator -reports:./TestResults/**/coverage.cobertura.xml -targetdir:${{env.BUILD_ARTIFACT_PATH}}/TestResults/Coverage/Reports "-reporttypes:HtmlInline;HTMLChart;Cobertura"
+    - name: 'Generate Merged Coverage Report'
+      run: reportgenerator -reports:"./artifacts/**/coverage.cobertura.xml" -targetdir:${{env.BUILD_ARTIFACT_PATH}}/TestResults/Coverage/Reports "-reporttypes:HtmlInline;HTMLChart;Cobertura"
     - name: 'Upload Coverage'
       uses: codecov/codecov-action@v4
       with:
-        file: Cobertura.xml
+        file: ${{env.BUILD_ARTIFACT_PATH}}/TestResults/Coverage/Reports/Cobertura.xml
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: 'Publish Coverage Report'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.os}}
-        path: ${{env.BUILD_ARTIFACT_PATH}}
+        path: |
+          ${{env.BUILD_ARTIFACT_PATH}}
+          !${{env.BUILD_ARTIFACT_PATH}}/**/In/**/*
 
   coverage:
     name: 'Process Coverage'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
           10.0.x
     - name: 'Install ReportGenerator'
       run: dotnet tool install -g dotnet-reportgenerator-globaltool
+    - name: 'List Coverage Files'
+      run: find ./artifacts -name "coverage.cobertura.xml" -type f
     - name: 'Generate Merged Coverage Report'
       run: reportgenerator -reports:"./artifacts/**/coverage.cobertura.xml" -targetdir:${{env.BUILD_ARTIFACT_PATH}}/TestResults/Coverage/Reports "-reporttypes:HtmlInline;HTMLChart;Cobertura"
     - name: 'Upload Coverage'

--- a/NaCl.Core.sln
+++ b/NaCl.Core.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2002
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11205.157 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NaCl.Core", "src\NaCl.Core\NaCl.Core.csproj", "{5B711EBA-6E41-429F-A2AC-719C4441B663}"
 EndProject
@@ -11,8 +11,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NaCl.Core.Benchmarks", "tes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{28EF1FB3-A057-4C17-A3B2-B9370B234F81}"
 	ProjectSection(SolutionItems) = preProject
-		CodeCoverage.runsettings = CodeCoverage.runsettings
 		build.cake = build.cake
+		.github\workflows\ci.yml = .github\workflows\ci.yml
+		CodeCoverage.runsettings = CodeCoverage.runsettings
 		dotnet-tools.json = dotnet-tools.json
 		global.json = global.json
 		LICENSE = LICENSE

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Daily NuGet builds of the project are also available in the [Azure Artifacts](ht
 #### Symmetric Key Encryption
 
 ```csharp
-// Create the primitive
-var aead = new ChaCha20Poly1305(key);
+// Create the primitive (implements IDisposable for secure key cleanup)
+using var aead = new ChaCha20Poly1305(key);
 
 // Use the primitive to encrypt a plaintext
 aead.Encrypt(nonce, plaintext, ciphertext, tag, aad);
@@ -57,6 +57,8 @@ aead.Encrypt(nonce, plaintext, ciphertext, tag, aad);
 // ... or to decrypt a ciphertext
 aead.Decrypt(nonce, ciphertext, tag, plaintext, aad);
 ```
+
+> **Note:** All cipher classes (`ChaCha20`, `XChaCha20`, `Salsa20`, `XSalsa20`, `ChaCha20Poly1305`, `XChaCha20Poly1305`) implement `IDisposable`. Call `Dispose()` or use `using` statements to securely zero the key from memory when done.
 
 #### MAC (Message Authentication Code)
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ Poly1305.VerifyMac(key, data, tag);
 - Includes the mandatory RFC [test vectors](https://github.com/daviddesmet/NaCl.Core/tree/master/test/NaCl.Core.Tests).
 - [Project Wycheproof](https://github.com/google/wycheproof) by members of Google Security Team, for testing against known attacks (when applicable).
 
+## Performance
+
+Refer to the [benchmarks](https://github.com/daviddesmet/NaCl.Core/tree/master/test/NaCl.Core.Benchmarks) for performance numbers.
+
+Run the benchmarks using:
+```bash
+dotnet run -c Release --framework net9.0
+```
+
+```bash
+dotnet run -c Release --framework net9.0 --filter "*ChaCha20IntrinsicsBenchmark*"
+```
+
 ## Learn More
 
 [![License](https://img.shields.io/github/license/daviddesmet/NaCl.Core.svg)](https://github.com/daviddesmet/NaCl.Core/blob/master/LICENSE)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
       projects: '**/NaCl.Core.Tests.csproj'
       arguments: '/p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Include="[NaCl.*]*" /p:Exclude="[*Tests]*"'
     enabled: false
-  - task: reportgenerator@4
+  - task: reportgenerator@5
     displayName: 'Generate Coverage Report'
     inputs:
       reports: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
@@ -206,6 +206,7 @@ jobs:
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
       nuGetFeedType: 'internal'
       publishVstsFeed: 'ffbd9fd0-ffca-4040-8576-0fa5065bd6d9/b465c74e-3671-458e-996f-8bbf45f957bc'
+    continueOnError: true
   - task: DotNetCoreCLI@2
     displayName: 'Publish Library'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,10 +58,11 @@ jobs:
   # The steps to run to execute the build.
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET SDK 9.0'
+    displayName: 'Use .NET SDK 10.0'
     inputs:
       packageType: 'sdk'
-      version: '9.0.x'
+      version: '10.0.x'
+      includePreviewVersions: true
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: DotNetCoreCLI@2
     displayName: 'Build Project in $(BuildConfiguration) mode'
@@ -69,7 +70,7 @@ jobs:
       command: 'build'
       projects: '**/NaCl.Core.csproj'
       arguments: '-c $(BuildConfiguration)'
-  - script: dotnet test -f net9.0 test/NaCl.Core.Tests --logger trx /p:CollectCoverage=true /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/ /p:CoverletOutputFormat=cobertura /p:Exclude='[NaCl.Core.Tests]*'
+  - script: dotnet test -f net10.0 test/NaCl.Core.Tests --logger trx /p:CollectCoverage=true /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/ /p:CoverletOutputFormat=cobertura /p:Exclude='[NaCl.Core.Tests]*'
     displayName: 'Unit testing'
     enabled: false
   - task: DotNetCoreCLI@2
@@ -86,7 +87,7 @@ jobs:
       targetdir: '$(Build.ArtifactStagingDirectory)/TestResults/'
       reporttypes: 'HtmlInline_AzurePipelines_Dark;Cobertura;Badges'
     enabled: false
-  - script: dotnet test -f net9.0 test/NaCl.Core.Tests --logger trx
+  - script: dotnet test -f net10.0 test/NaCl.Core.Tests --logger trx
     displayName: 'Run Unit Tests'
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
@@ -108,7 +109,7 @@ jobs:
     displayName: 'Publish Library'
     inputs:
       command: 'publish'
-      arguments: '-c $(BuildConfiguration) -f net9.0 -o $(Build.ArtifactStagingDirectory) --no-restore'
+      arguments: '-c $(BuildConfiguration) -f net10.0 -o $(Build.ArtifactStagingDirectory) --no-restore'
       projects: src/NaCl.Core/NaCl.Core.csproj
       publishWebProjects: false
       modifyOutputPath: true
@@ -132,16 +133,17 @@ jobs:
     BuildConfiguration: 'release'
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET SDK 9.0'
+    displayName: 'Use .NET SDK 10.0'
     inputs:
       packageType: 'sdk'
-      version: '9.0.x'
+      version: '10.0.x'
+      includePreviewVersions: true
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - script: dotnet restore
     displayName: 'Restore Project'
   - script: dotnet build -c $(BuildConfiguration) --no-restore
     displayName: 'Build Project in $(BuildConfiguration) mode'
-  - script: dotnet test -f net9.0 test/NaCl.Core.Tests --logger trx
+  - script: dotnet test -f net10.0 test/NaCl.Core.Tests --logger trx
     displayName: 'Run Unit Tests'
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
@@ -164,10 +166,11 @@ jobs:
     displayName: 'Authenticate with Azure Artifacts'
     condition: ne(variables['Build.Reason'], 'PullRequest')
   - task: UseDotNet@2
-    displayName: 'Use .NET SDK 9.0'
+    displayName: 'Use .NET SDK 10.0'
     inputs:
       packageType: 'sdk'
-      version: '9.0.x'
+      version: '10.0.x'
+      includePreviewVersions: true
   - task: DotNetCoreCLI@2
     displayName: 'Build Project in $(BuildConfiguration) mode'
     inputs:
@@ -211,7 +214,7 @@ jobs:
     displayName: 'Publish Library'
     inputs:
       command: 'publish'
-      arguments: '-c $(BuildConfiguration) -f net9.0 -o $(Build.ArtifactStagingDirectory) --no-restore'
+      arguments: '-c $(BuildConfiguration) -f net10.0 -o $(Build.ArtifactStagingDirectory) --no-restore'
       projects: src/NaCl.Core/NaCl.Core.csproj
       publishWebProjects: false
     enabled: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,6 +209,7 @@ jobs:
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
       nuGetFeedType: 'internal'
       publishVstsFeed: 'ffbd9fd0-ffca-4040-8576-0fa5065bd6d9/b465c74e-3671-458e-996f-8bbf45f957bc'
+      allowPackageConflicts: true
     continueOnError: true
   - task: DotNetCoreCLI@2
     displayName: 'Publish Library'

--- a/build.cake
+++ b/build.cake
@@ -63,10 +63,12 @@ Task("Test")
         {
             // ARM/Mac testing with AdvSIMD
             settings.EnvironmentVariables["COMPlus_EnableAdvSimd"] = "1";
+            settings.ResultsDirectory = $"{artifactsDirectory}/TestResults/AdvSimd";
             Information($"Running default {project.GetFilename()} test with ARM AdvSIMD enabled");
             DotNetTest(project.ToString(), settings);
 
             settings.EnvironmentVariables["COMPlus_EnableAdvSimd"] = "0";
+            settings.ResultsDirectory = $"{artifactsDirectory}/TestResults/Scalar";
             Information($"Running {project.GetFilename()} test with ARM AdvSIMD disabled (scalar only)");
             DotNetTest(project.ToString(), settings);
         }
@@ -75,16 +77,19 @@ Task("Test")
             // x86/x64 testing with AVX2/SSE3
             settings.EnvironmentVariables["COMPlus_EnableAVX2"] = "1";
             settings.EnvironmentVariables["COMPlus_EnableSSE3"] = "1";
+            settings.ResultsDirectory = $"{artifactsDirectory}/TestResults/Avx2";
             Information($"Running default {project.GetFilename()} test with SSE3 and AVX2 enabled");
             DotNetTest(project.ToString(), settings);
 
             settings.EnvironmentVariables["COMPlus_EnableAVX2"] = "0";
             settings.EnvironmentVariables["COMPlus_EnableSSE3"] = "1";
+            settings.ResultsDirectory = $"{artifactsDirectory}/TestResults/Sse3";
             Information($"Running {project.GetFilename()} test with SSE3 enabled and AVX2 disabled");
             DotNetTest(project.ToString(), settings);
 
             settings.EnvironmentVariables["COMPlus_EnableAVX2"] = "0";
             settings.EnvironmentVariables["COMPlus_EnableSSE3"] = "0";
+            settings.ResultsDirectory = $"{artifactsDirectory}/TestResults/Scalar";
             Information($"Running {project.GetFilename()} test with SSE3 and AVX2 disabled");
             DotNetTest(project.ToString(), settings);
         }

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,3 @@
-#tool nuget:?package=ReportGenerator&version=5.3.0
-
 var target = Argument("Target", "Default");
 var configuration =
     HasArgument("Configuration") ? Argument<string>("Configuration") :
@@ -61,13 +59,13 @@ Task("Test")
         };
 
         // Platform-specific intrinsics testing
-        if (IsRunningOnUnix() && Environment.OSVersion.Platform == PlatformID.Unix)
+        if (IsRunningOnUnix())
         {
             // ARM/Mac testing with AdvSIMD
             settings.EnvironmentVariables["COMPlus_EnableAdvSimd"] = "1";
             Information($"Running default {project.GetFilename()} test with ARM AdvSIMD enabled");
             DotNetTest(project.ToString(), settings);
-            
+
             settings.EnvironmentVariables["COMPlus_EnableAdvSimd"] = "0";
             Information($"Running {project.GetFilename()} test with ARM AdvSIMD disabled (scalar only)");
             DotNetTest(project.ToString(), settings);
@@ -128,7 +126,6 @@ Task("Default")
     .Description("Cleans, restores, builds the solution, runs unit tests and then create the NuGet packages.")
     .IsDependentOn("Build")
     .IsDependentOn("Test")
-    .IsDependentOn("CoverageReport")
     .IsDependentOn("Pack");
 
 RunTarget(target);

--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,5 @@
+#tool nuget:?package=ReportGenerator&version=5.3.0
+
 var target = Argument("Target", "Default");
 var configuration =
     HasArgument("Configuration") ? Argument<string>("Configuration") :
@@ -42,23 +44,52 @@ Task("Test")
     {
         Information($"Preparing {project.GetFilename()} for test");
 
-        DotNetTest(
-            project.ToString(),
-            new DotNetTestSettings()
+        var settings = new DotNetTestSettings()
+        {
+            Blame = true,
+            Collectors = new string[] { "XPlat Code Coverage" },
+            Configuration = configuration,
+            Loggers = new string[]
             {
-                Blame = true,
-                Collectors = new string[] { "XPlat Code Coverage" },
-                Configuration = configuration,
-                Loggers = new string[]
-                {
-                    $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                    $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
-                },
-                NoBuild = true,
-                NoRestore = true,
-                ResultsDirectory = $"{artifactsDirectory}/TestResults",
-                Settings = "CodeCoverage.runsettings"
-            });
+                $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+            },
+            NoBuild = true,
+            NoRestore = true,
+            ResultsDirectory = $"{artifactsDirectory}/TestResults",
+            Settings = "CodeCoverage.runsettings"
+        };
+
+        // Platform-specific intrinsics testing
+        if (IsRunningOnUnix() && Environment.OSVersion.Platform == PlatformID.Unix)
+        {
+            // ARM/Mac testing with AdvSIMD
+            settings.EnvironmentVariables["COMPlus_EnableAdvSimd"] = "1";
+            Information($"Running default {project.GetFilename()} test with ARM AdvSIMD enabled");
+            DotNetTest(project.ToString(), settings);
+            
+            settings.EnvironmentVariables["COMPlus_EnableAdvSimd"] = "0";
+            Information($"Running {project.GetFilename()} test with ARM AdvSIMD disabled (scalar only)");
+            DotNetTest(project.ToString(), settings);
+        }
+        else
+        {
+            // x86/x64 testing with AVX2/SSE3
+            settings.EnvironmentVariables["COMPlus_EnableAVX2"] = "1";
+            settings.EnvironmentVariables["COMPlus_EnableSSE3"] = "1";
+            Information($"Running default {project.GetFilename()} test with SSE3 and AVX2 enabled");
+            DotNetTest(project.ToString(), settings);
+
+            settings.EnvironmentVariables["COMPlus_EnableAVX2"] = "0";
+            settings.EnvironmentVariables["COMPlus_EnableSSE3"] = "1";
+            Information($"Running {project.GetFilename()} test with SSE3 enabled and AVX2 disabled");
+            DotNetTest(project.ToString(), settings);
+
+            settings.EnvironmentVariables["COMPlus_EnableAVX2"] = "0";
+            settings.EnvironmentVariables["COMPlus_EnableSSE3"] = "0";
+            Information($"Running {project.GetFilename()} test with SSE3 and AVX2 disabled");
+            DotNetTest(project.ToString(), settings);
+        }
     });
 
 Task("CoverageReport")
@@ -72,7 +103,7 @@ Task("CoverageReport")
                             ArgumentCustomization = args => args.Append("-reporttypes:HtmlInline;HTMLChart;Cobertura")
                         });
     });
-        
+
 Task("Pack")
     .Description("Creates the NuGet packages and outputs them to the artifacts directory.")
     .Does(() =>
@@ -97,6 +128,7 @@ Task("Default")
     .Description("Cleans, restores, builds the solution, runs unit tests and then create the NuGet packages.")
     .IsDependentOn("Build")
     .IsDependentOn("Test")
+    .IsDependentOn("CoverageReport")
     .IsDependentOn("Pack");
 
 RunTarget(target);

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.101",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/NaCl.Core/Base/ChaCha20Base.cs
+++ b/src/NaCl.Core/Base/ChaCha20Base.cs
@@ -278,43 +278,41 @@ public abstract class ChaCha20Base : Snuffle
 
 #if NET6_0_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ShuffleStateAvx2(Span<uint> state)
+    private static unsafe void ShuffleStateAvx2(Span<uint> state)
     {
-        // Load the state into AVX2 registers
-        var row1 = Vector256.Create(state[0], state[1], state[2], state[3], state[0], state[1], state[2], state[3]);
-        var row2 = Vector256.Create(state[4], state[5], state[6], state[7], state[4], state[5], state[6], state[7]);
-        var row3 = Vector256.Create(state[8], state[9], state[10], state[11], state[8], state[9], state[10], state[11]);
-        var row4 = Vector256.Create(state[12], state[13], state[14], state[15], state[12], state[13], state[14], state[15]);
-
-        // Perform 20 rounds (10 double rounds)
-        for (var i = 0; i < 10; i++)
+        // Use Vector128 operations instead of wasting Vector256 capacity
+        // This is more efficient for single-block processing
+        fixed (uint* statePtr = state)
         {
-            // Column rounds
-            QuarterRoundAvx2(ref row1, ref row2, ref row3, ref row4);
+            var row1 = Sse2.LoadVector128(statePtr + 0);  // state[0..3]
+            var row2 = Sse2.LoadVector128(statePtr + 4);  // state[4..7]
+            var row3 = Sse2.LoadVector128(statePtr + 8);  // state[8..11]
+            var row4 = Sse2.LoadVector128(statePtr + 12); // state[12..15]
 
-            // Diagonal rounds - rotate the rows for diagonal access
-            row2 = Avx2.Shuffle(row2.AsUInt32(), 0x39).AsUInt32(); // Rotate left by 1
-            row3 = Avx2.Shuffle(row3.AsUInt32(), 0x4E).AsUInt32(); // Rotate left by 2
-            row4 = Avx2.Shuffle(row4.AsUInt32(), 0x93).AsUInt32(); // Rotate left by 3
-
-            QuarterRoundAvx2(ref row1, ref row2, ref row3, ref row4);
-
-            // Rotate back
-            row2 = Avx2.Shuffle(row2.AsUInt32(), 0x93).AsUInt32(); // Rotate right by 1
-            row3 = Avx2.Shuffle(row3.AsUInt32(), 0x4E).AsUInt32(); // Rotate right by 2
-            row4 = Avx2.Shuffle(row4.AsUInt32(), 0x39).AsUInt32(); // Rotate right by 3
-        }
-
-        // Store the results back
-        unsafe
-        {
-            fixed (uint* statePtr = state)
+            // Perform 20 rounds (10 double rounds)
+            for (var i = 0; i < 10; i++)
             {
-                Sse2.Store(statePtr + 0, row1.GetLower());
-                Sse2.Store(statePtr + 4, row2.GetLower());
-                Sse2.Store(statePtr + 8, row3.GetLower());
-                Sse2.Store(statePtr + 12, row4.GetLower());
+                // Column rounds
+                QuarterRoundSsse3(ref row1, ref row2, ref row3, ref row4);
+
+                // Diagonal rounds - rotate the rows for diagonal access
+                row2 = Sse2.Shuffle(row2, 0x39); // Rotate left by 1
+                row3 = Sse2.Shuffle(row3, 0x4E); // Rotate left by 2
+                row4 = Sse2.Shuffle(row4, 0x93); // Rotate left by 3
+
+                QuarterRoundSsse3(ref row1, ref row2, ref row3, ref row4);
+
+                // Rotate back
+                row2 = Sse2.Shuffle(row2, 0x93); // Rotate right by 1
+                row3 = Sse2.Shuffle(row3, 0x4E); // Rotate right by 2
+                row4 = Sse2.Shuffle(row4, 0x39); // Rotate right by 3
             }
+
+            // Store the results back efficiently - using full vector width
+            Sse2.Store(statePtr + 0, row1);
+            Sse2.Store(statePtr + 4, row2);
+            Sse2.Store(statePtr + 8, row3);
+            Sse2.Store(statePtr + 12, row4);
         }
     }
 
@@ -415,8 +413,68 @@ public abstract class ChaCha20Base : Snuffle
     }
 
 #if NET6_0_OR_GREATER
+    /// <summary>
+    /// Processes two ChaCha20 blocks in parallel using full AVX2 256-bit vectors.
+    /// This approach efficiently uses the full vector capacity for multiple blocks.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void QuarterRoundAvx2(ref Vector256<uint> row1, ref Vector256<uint> row2, ref Vector256<uint> row3, ref Vector256<uint> row4)
+    private static unsafe void ShuffleStateDualBlockAvx2(Span<uint> state1, Span<uint> state2)
+    {
+        fixed (uint* state1Ptr = state1)
+        fixed (uint* state2Ptr = state2)
+        {
+            // Load two blocks into 256-bit vectors - efficient use of full vector capacity
+            var row1 = Vector256.Create(
+                state1[0], state1[1], state1[2], state1[3],  // Block 1
+                state2[0], state2[1], state2[2], state2[3]   // Block 2
+            );
+            var row2 = Vector256.Create(
+                state1[4], state1[5], state1[6], state1[7],
+                state2[4], state2[5], state2[6], state2[7]
+            );
+            var row3 = Vector256.Create(
+                state1[8], state1[9], state1[10], state1[11],
+                state2[8], state2[9], state2[10], state2[11]
+            );
+            var row4 = Vector256.Create(
+                state1[12], state1[13], state1[14], state1[15],
+                state2[12], state2[13], state2[14], state2[15]
+            );
+
+            // Perform 20 rounds (10 double rounds) on both blocks simultaneously
+            for (var i = 0; i < 10; i++)
+            {
+                // Column rounds
+                QuarterRoundAvx2DualBlock(ref row1, ref row2, ref row3, ref row4);
+
+                // Diagonal rounds - rotate for diagonal access
+                row2 = Avx2.Shuffle(row2, 0x39); // Rotate left by 1
+                row3 = Avx2.Shuffle(row3, 0x4E); // Rotate left by 2
+                row4 = Avx2.Shuffle(row4, 0x93); // Rotate left by 3
+
+                QuarterRoundAvx2DualBlock(ref row1, ref row2, ref row3, ref row4);
+
+                // Rotate back
+                row2 = Avx2.Shuffle(row2, 0x93); // Rotate right by 1
+                row3 = Avx2.Shuffle(row3, 0x4E); // Rotate right by 2
+                row4 = Avx2.Shuffle(row4, 0x39); // Rotate right by 3
+            }
+
+            // Store both blocks back efficiently using full 256-bit vectors
+            Sse2.Store(state1Ptr + 0, row1.GetLower());
+            Sse2.Store(state1Ptr + 4, row2.GetLower());
+            Sse2.Store(state1Ptr + 8, row3.GetLower());
+            Sse2.Store(state1Ptr + 12, row4.GetLower());
+
+            Sse2.Store(state2Ptr + 0, row1.GetUpper());
+            Sse2.Store(state2Ptr + 4, row2.GetUpper());
+            Sse2.Store(state2Ptr + 8, row3.GetUpper());
+            Sse2.Store(state2Ptr + 12, row4.GetUpper());
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void QuarterRoundAvx2DualBlock(ref Vector256<uint> row1, ref Vector256<uint> row2, ref Vector256<uint> row3, ref Vector256<uint> row4)
     {
         // a += b
         row1 = Avx2.Add(row1, row2);

--- a/src/NaCl.Core/Base/ChaCha20Base.cs
+++ b/src/NaCl.Core/Base/ChaCha20Base.cs
@@ -3,13 +3,20 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+#if NET6_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+#endif
 
 using Internal;
 
 /// <summary>
-/// Base class for <seealso cref="NaCl.Core.ChaCha20" /> and <seealso cref="NaCl.Core.XChaCha20" />.
+/// Base class for <see cref="NaCl.Core.ChaCha20" /> and <see cref="NaCl.Core.XChaCha20" />.
 /// </summary>
 /// <seealso cref="NaCl.Core.Base.Snuffle" />
+/// <seealso cref="NaCl.Core.ChaCha20" />
+/// <seealso cref="NaCl.Core.XChaCha20" />
 public abstract class ChaCha20Base : Snuffle
 {
     /// <summary>
@@ -72,6 +79,8 @@ public abstract class ChaCha20Base : Snuffle
         // Block function
         ShuffleState(state);
 
+        // Final subkey = state[0..4] || state[12..16]
+        // state.Slice(12, 4).CopyTo(state.Slice(4, 4));
         state[4] = state[12];
         state[5] = state[13];
         state[6] = state[14];
@@ -226,6 +235,30 @@ public abstract class ChaCha20Base : Snuffle
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected static void ShuffleState(Span<uint> state)
     {
+#if NET6_0_OR_GREATER
+        if (Avx2.IsSupported)
+        {
+            ShuffleStateAvx2(state);
+            return;
+        }
+        if (Ssse3.IsSupported)
+        {
+            ShuffleStateSsse3(state);
+            return;
+        }
+        if (AdvSimd.IsSupported)
+        {
+            ShuffleStateAdvSimd(state);
+            return;
+        }
+#endif
+        // Fallback to scalar implementation
+        ShuffleStateScalar(state);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ShuffleStateScalar(Span<uint> state)
+    {
         // 10 loops × 2 rounds/loop = 20 rounds
         for (var i = 0; i < 10; i++)
         {
@@ -243,6 +276,131 @@ public abstract class ChaCha20Base : Snuffle
         }
     }
 
+#if NET6_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ShuffleStateAvx2(Span<uint> state)
+    {
+        // Load the state into AVX2 registers
+        var row1 = Vector256.Create(state[0], state[1], state[2], state[3], state[0], state[1], state[2], state[3]);
+        var row2 = Vector256.Create(state[4], state[5], state[6], state[7], state[4], state[5], state[6], state[7]);
+        var row3 = Vector256.Create(state[8], state[9], state[10], state[11], state[8], state[9], state[10], state[11]);
+        var row4 = Vector256.Create(state[12], state[13], state[14], state[15], state[12], state[13], state[14], state[15]);
+
+        // Perform 20 rounds (10 double rounds)
+        for (var i = 0; i < 10; i++)
+        {
+            // Column rounds
+            QuarterRoundAvx2(ref row1, ref row2, ref row3, ref row4);
+
+            // Diagonal rounds - rotate the rows for diagonal access
+            row2 = Avx2.Shuffle(row2.AsUInt32(), 0x39).AsUInt32(); // Rotate left by 1
+            row3 = Avx2.Shuffle(row3.AsUInt32(), 0x4E).AsUInt32(); // Rotate left by 2
+            row4 = Avx2.Shuffle(row4.AsUInt32(), 0x93).AsUInt32(); // Rotate left by 3
+
+            QuarterRoundAvx2(ref row1, ref row2, ref row3, ref row4);
+
+            // Rotate back
+            row2 = Avx2.Shuffle(row2.AsUInt32(), 0x93).AsUInt32(); // Rotate right by 1
+            row3 = Avx2.Shuffle(row3.AsUInt32(), 0x4E).AsUInt32(); // Rotate right by 2
+            row4 = Avx2.Shuffle(row4.AsUInt32(), 0x39).AsUInt32(); // Rotate right by 3
+        }
+
+        // Store the results back
+        unsafe
+        {
+            fixed (uint* statePtr = state)
+            {
+                Sse2.Store(statePtr + 0, row1.GetLower());
+                Sse2.Store(statePtr + 4, row2.GetLower());
+                Sse2.Store(statePtr + 8, row3.GetLower());
+                Sse2.Store(statePtr + 12, row4.GetLower());
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ShuffleStateSsse3(Span<uint> state)
+    {
+        // Load the state into SSE registers
+        var row1 = Vector128.Create(state[0], state[1], state[2], state[3]);
+        var row2 = Vector128.Create(state[4], state[5], state[6], state[7]);
+        var row3 = Vector128.Create(state[8], state[9], state[10], state[11]);
+        var row4 = Vector128.Create(state[12], state[13], state[14], state[15]);
+
+        // Perform 20 rounds (10 double rounds)
+        for (var i = 0; i < 10; i++)
+        {
+            // Column rounds
+            QuarterRoundSsse3(ref row1, ref row2, ref row3, ref row4);
+
+            // Diagonal rounds - rotate the rows for diagonal access
+            row2 = Ssse3.Shuffle(row2.AsByte(), Vector128.Create((byte)4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3)).AsUInt32();
+            row3 = Ssse3.Shuffle(row3.AsByte(), Vector128.Create((byte)8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7)).AsUInt32();
+            row4 = Ssse3.Shuffle(row4.AsByte(), Vector128.Create((byte)12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)).AsUInt32();
+
+            QuarterRoundSsse3(ref row1, ref row2, ref row3, ref row4);
+
+            // Rotate back
+            row2 = Ssse3.Shuffle(row2.AsByte(), Vector128.Create((byte)12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)).AsUInt32();
+            row3 = Ssse3.Shuffle(row3.AsByte(), Vector128.Create((byte)8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7)).AsUInt32();
+            row4 = Ssse3.Shuffle(row4.AsByte(), Vector128.Create((byte)4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3)).AsUInt32();
+        }
+
+        // Store the results back
+        unsafe
+        {
+            fixed (uint* statePtr = state)
+            {
+                Sse2.Store(statePtr + 0, row1);
+                Sse2.Store(statePtr + 4, row2);
+                Sse2.Store(statePtr + 8, row3);
+                Sse2.Store(statePtr + 12, row4);
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ShuffleStateAdvSimd(Span<uint> state)
+    {
+        // Load the state into ARM AdvSIMD registers
+        var row1 = Vector128.Create(state[0], state[1], state[2], state[3]);
+        var row2 = Vector128.Create(state[4], state[5], state[6], state[7]);
+        var row3 = Vector128.Create(state[8], state[9], state[10], state[11]);
+        var row4 = Vector128.Create(state[12], state[13], state[14], state[15]);
+
+        // Perform 20 rounds (10 double rounds)
+        for (var i = 0; i < 10; i++)
+        {
+            // Column rounds
+            QuarterRoundAdvSimd(ref row1, ref row2, ref row3, ref row4);
+            
+            // Diagonal rounds - rotate the rows for diagonal access
+            row2 = AdvSimd.ExtractVector128(row2.AsByte(), row2.AsByte(), 4).AsUInt32(); // Rotate left by 1 element
+            row3 = AdvSimd.ExtractVector128(row3.AsByte(), row3.AsByte(), 8).AsUInt32(); // Rotate left by 2 elements  
+            row4 = AdvSimd.ExtractVector128(row4.AsByte(), row4.AsByte(), 12).AsUInt32(); // Rotate left by 3 elements
+            
+            QuarterRoundAdvSimd(ref row1, ref row2, ref row3, ref row4);
+            
+            // Rotate back
+            row2 = AdvSimd.ExtractVector128(row2.AsByte(), row2.AsByte(), 12).AsUInt32(); // Rotate right by 1 element
+            row3 = AdvSimd.ExtractVector128(row3.AsByte(), row3.AsByte(), 8).AsUInt32(); // Rotate right by 2 elements
+            row4 = AdvSimd.ExtractVector128(row4.AsByte(), row4.AsByte(), 4).AsUInt32(); // Rotate right by 3 elements
+        }
+
+        // Store the results back
+        unsafe
+        {
+            fixed (uint* statePtr = state)
+            {
+                AdvSimd.Store(statePtr + 0, row1);
+                AdvSimd.Store(statePtr + 4, row2);
+                AdvSimd.Store(statePtr + 8, row3);
+                AdvSimd.Store(statePtr + 12, row4);
+            }
+        }
+    }
+#endif
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void QuarterRound(ref uint a, ref uint b, ref uint c, ref uint d)
     {
@@ -256,12 +414,90 @@ public abstract class ChaCha20Base : Snuffle
         b = BitUtils.RotateLeft(b ^ c, 7);
     }
 
+#if NET6_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void QuarterRoundAvx2(ref Vector256<uint> row1, ref Vector256<uint> row2, ref Vector256<uint> row3, ref Vector256<uint> row4)
+    {
+        // a += b
+        row1 = Avx2.Add(row1, row2);
+        // d ^= a, d <<<= 16
+        row4 = Avx2.Xor(row4, row1);
+        row4 = BitUtils.RotateLeftVector256(row4, 16);
+        // c += d
+        row3 = Avx2.Add(row3, row4);
+        // b ^= c, b <<<= 12
+        row2 = Avx2.Xor(row2, row3);
+        row2 = BitUtils.RotateLeftVector256(row2, 12);
+        // a += b
+        row1 = Avx2.Add(row1, row2);
+        // d ^= a, d <<<= 8
+        row4 = Avx2.Xor(row4, row1);
+        row4 = BitUtils.RotateLeftVector256(row4, 8);
+        // c += d
+        row3 = Avx2.Add(row3, row4);
+        // b ^= c, b <<<= 7
+        row2 = Avx2.Xor(row2, row3);
+        row2 = BitUtils.RotateLeftVector256(row2, 7);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void QuarterRoundSsse3(ref Vector128<uint> row1, ref Vector128<uint> row2, ref Vector128<uint> row3, ref Vector128<uint> row4)
+    {
+        // a += b
+        row1 = Sse2.Add(row1, row2);
+        // d ^= a, d <<<= 16
+        row4 = Sse2.Xor(row4, row1);
+        row4 = BitUtils.RotateLeftVector128(row4, 16);
+        // c += d
+        row3 = Sse2.Add(row3, row4);
+        // b ^= c, b <<<= 12
+        row2 = Sse2.Xor(row2, row3);
+        row2 = BitUtils.RotateLeftVector128(row2, 12);
+        // a += b
+        row1 = Sse2.Add(row1, row2);
+        // d ^= a, d <<<= 8
+        row4 = Sse2.Xor(row4, row1);
+        row4 = BitUtils.RotateLeftVector128(row4, 8);
+        // c += d
+        row3 = Sse2.Add(row3, row4);
+        // b ^= c, b <<<= 7
+        row2 = Sse2.Xor(row2, row3);
+        row2 = BitUtils.RotateLeftVector128(row2, 7);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void QuarterRoundAdvSimd(ref Vector128<uint> row1, ref Vector128<uint> row2, ref Vector128<uint> row3, ref Vector128<uint> row4)
+    {
+        // a += b
+        row1 = AdvSimd.Add(row1, row2);
+        // d ^= a, d <<<= 16
+        row4 = AdvSimd.Xor(row4, row1);
+        row4 = BitUtils.RotateLeftAdvSimd(row4, 16);
+        // c += d
+        row3 = AdvSimd.Add(row3, row4);
+        // b ^= c, b <<<= 12
+        row2 = AdvSimd.Xor(row2, row3);
+        row2 = BitUtils.RotateLeftAdvSimd(row2, 12);
+        // a += b
+        row1 = AdvSimd.Add(row1, row2);
+        // d ^= a, d <<<= 8
+        row4 = AdvSimd.Xor(row4, row1);
+        row4 = BitUtils.RotateLeftAdvSimd(row4, 8);
+        // c += d
+        row3 = AdvSimd.Add(row3, row4);
+        // b ^= c, b <<<= 7
+        row2 = AdvSimd.Xor(row2, row3);
+        row2 = BitUtils.RotateLeftAdvSimd(row2, 7);
+    }
+#endif
+
     /// <summary>
     /// Sets the ChaCha20 constant.
     /// </summary>
     /// <param name="state">The state.</param>
     protected static void SetSigma(Span<uint> state)
     {
+        // SIGMA.AsSpan()[..4].CopyTo(state);
         state[0] = SIGMA[0];
         state[1] = SIGMA[1];
         state[2] = SIGMA[2];

--- a/src/NaCl.Core/Base/ChaCha20Base.cs
+++ b/src/NaCl.Core/Base/ChaCha20Base.cs
@@ -10,6 +10,7 @@ using System.Runtime.Intrinsics.Arm;
 #endif
 
 using Internal;
+using System.Diagnostics.CodeAnalysis;
 
 /// <summary>
 /// Base class for <see cref="NaCl.Core.ChaCha20" /> and <see cref="NaCl.Core.XChaCha20" />.
@@ -371,14 +372,14 @@ public abstract class ChaCha20Base : Snuffle
         {
             // Column rounds
             QuarterRoundAdvSimd(ref row1, ref row2, ref row3, ref row4);
-            
+
             // Diagonal rounds - rotate the rows for diagonal access
             row2 = AdvSimd.ExtractVector128(row2.AsByte(), row2.AsByte(), 4).AsUInt32(); // Rotate left by 1 element
             row3 = AdvSimd.ExtractVector128(row3.AsByte(), row3.AsByte(), 8).AsUInt32(); // Rotate left by 2 elements  
             row4 = AdvSimd.ExtractVector128(row4.AsByte(), row4.AsByte(), 12).AsUInt32(); // Rotate left by 3 elements
-            
+
             QuarterRoundAdvSimd(ref row1, ref row2, ref row3, ref row4);
-            
+
             // Rotate back
             row2 = AdvSimd.ExtractVector128(row2.AsByte(), row2.AsByte(), 12).AsUInt32(); // Rotate right by 1 element
             row3 = AdvSimd.ExtractVector128(row3.AsByte(), row3.AsByte(), 8).AsUInt32(); // Rotate right by 2 elements
@@ -417,6 +418,7 @@ public abstract class ChaCha20Base : Snuffle
     /// Processes two ChaCha20 blocks in parallel using full AVX2 256-bit vectors.
     /// This approach efficiently uses the full vector capacity for multiple blocks.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static unsafe void ShuffleStateDualBlockAvx2(Span<uint> state1, Span<uint> state2)
     {
@@ -473,6 +475,7 @@ public abstract class ChaCha20Base : Snuffle
         }
     }
 
+    [ExcludeFromCodeCoverage]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void QuarterRoundAvx2DualBlock(ref Vector256<uint> row1, ref Vector256<uint> row2, ref Vector256<uint> row3, ref Vector256<uint> row4)
     {

--- a/src/NaCl.Core/Base/Salsa20Base.cs
+++ b/src/NaCl.Core/Base/Salsa20Base.cs
@@ -7,9 +7,11 @@ using System.Security.Cryptography;
 using Internal;
 
 /// <summary>
-/// Base class for <seealso cref="NaCl.Core.Salsa20" /> and <seealso cref="NaCl.Core.XSalsa20" />.
+/// Base class for <see cref="NaCl.Core.Salsa20" /> and <see cref="NaCl.Core.XSalsa20" />.
 /// </summary>
 /// <seealso cref="NaCl.Core.Base.Snuffle" />
+/// <seealso cref="NaCl.Core.Salsa20" />
+/// <seealso cref="NaCl.Core.XSalsa20" />
 public abstract class Salsa20Base : Snuffle
 {
     /// <summary>

--- a/src/NaCl.Core/Base/Salsa20Base.cs
+++ b/src/NaCl.Core/Base/Salsa20Base.cs
@@ -3,6 +3,11 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+#if NET6_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+#endif
 
 using Internal;
 
@@ -116,6 +121,29 @@ public abstract class Salsa20Base : Snuffle
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected static void ShuffleState(Span<uint> state)
     {
+#if NET6_0_OR_GREATER
+        if (Avx2.IsSupported && state.Length == BLOCK_SIZE_IN_INTS)
+        {
+            ShuffleStateAvx2(state);
+            return;
+        }
+        if (Sse2.IsSupported && state.Length == BLOCK_SIZE_IN_INTS)
+        {
+            ShuffleStateSse2(state);
+            return;
+        }
+        if (AdvSimd.IsSupported && state.Length == BLOCK_SIZE_IN_INTS)
+        {
+            ShuffleStateAdvSimd(state);
+            return;
+        }
+#endif
+        ShuffleStateScalar(state);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected static void ShuffleStateScalar(Span<uint> state)
+    {
         // 10 loops × 2 rounds/loop = 20 rounds
         for (var i = 0; i < 10; i++)
         {
@@ -132,6 +160,232 @@ public abstract class Salsa20Base : Snuffle
             QuarterRound(ref state[15], ref state[12], ref state[13], ref state[14]); // row 4
         }
     }
+
+#if NET6_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected static unsafe void ShuffleStateAvx2(Span<uint> state)
+    {
+        fixed (uint* statePtr = state)
+        {
+            var s0 = Avx.LoadVector256(statePtr + 0);
+            var s1 = Avx.LoadVector256(statePtr + 8);
+
+            // 10 loops × 2 rounds/loop = 20 rounds
+            for (var i = 0; i < 10; i++)
+            {
+                // Odd round - column operations
+                QuarterRoundAvx2(ref s0, ref s1, 0, 4, 8, 12);
+                QuarterRoundAvx2(ref s0, ref s1, 5, 9, 13, 1);
+                QuarterRoundAvx2(ref s0, ref s1, 10, 14, 2, 6);
+                QuarterRoundAvx2(ref s0, ref s1, 15, 3, 7, 11);
+
+                // Even round - row operations
+                QuarterRoundAvx2(ref s0, ref s1, 0, 1, 2, 3);
+                QuarterRoundAvx2(ref s0, ref s1, 5, 6, 7, 4);
+                QuarterRoundAvx2(ref s0, ref s1, 10, 11, 8, 9);
+                QuarterRoundAvx2(ref s0, ref s1, 15, 12, 13, 14);
+            }
+
+            Avx.Store(statePtr + 0, s0);
+            Avx.Store(statePtr + 8, s1);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected static unsafe void ShuffleStateSse2(Span<uint> state)
+    {
+        fixed (uint* statePtr = state)
+        {
+            var s0 = Sse2.LoadVector128(statePtr + 0);
+            var s1 = Sse2.LoadVector128(statePtr + 4);
+            var s2 = Sse2.LoadVector128(statePtr + 8);
+            var s3 = Sse2.LoadVector128(statePtr + 12);
+
+            // 10 loops × 2 rounds/loop = 20 rounds
+            for (var i = 0; i < 10; i++)
+            {
+                // Odd round - column operations
+                QuarterRoundSse2(ref s0, ref s1, ref s2, ref s3, 0, 4, 8, 12);
+                QuarterRoundSse2(ref s0, ref s1, ref s2, ref s3, 5, 9, 13, 1);
+                QuarterRoundSse2(ref s0, ref s1, ref s2, ref s3, 10, 14, 2, 6);
+                QuarterRoundSse2(ref s0, ref s1, ref s2, ref s3, 15, 3, 7, 11);
+
+                // Even round - row operations
+                QuarterRoundSse2(ref s0, ref s1, ref s2, ref s3, 0, 1, 2, 3);
+                QuarterRoundSse2(ref s0, ref s1, ref s2, ref s3, 5, 6, 7, 4);
+                QuarterRoundSse2(ref s0, ref s1, ref s2, ref s3, 10, 11, 8, 9);
+                QuarterRoundSse2(ref s0, ref s1, ref s2, ref s3, 15, 12, 13, 14);
+            }
+
+            Sse2.Store(statePtr + 0, s0);
+            Sse2.Store(statePtr + 4, s1);
+            Sse2.Store(statePtr + 8, s2);
+            Sse2.Store(statePtr + 12, s3);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected static unsafe void ShuffleStateAdvSimd(Span<uint> state)
+    {
+        fixed (uint* statePtr = state)
+        {
+            var s0 = AdvSimd.LoadVector128(statePtr + 0);
+            var s1 = AdvSimd.LoadVector128(statePtr + 4);
+            var s2 = AdvSimd.LoadVector128(statePtr + 8);
+            var s3 = AdvSimd.LoadVector128(statePtr + 12);
+
+            // 10 loops × 2 rounds/loop = 20 rounds
+            for (var i = 0; i < 10; i++)
+            {
+                // Odd round - column operations
+                QuarterRoundAdvSimd(ref s0, ref s1, ref s2, ref s3, 0, 4, 8, 12);
+                QuarterRoundAdvSimd(ref s0, ref s1, ref s2, ref s3, 5, 9, 13, 1);
+                QuarterRoundAdvSimd(ref s0, ref s1, ref s2, ref s3, 10, 14, 2, 6);
+                QuarterRoundAdvSimd(ref s0, ref s1, ref s2, ref s3, 15, 3, 7, 11);
+
+                // Even round - row operations
+                QuarterRoundAdvSimd(ref s0, ref s1, ref s2, ref s3, 0, 1, 2, 3);
+                QuarterRoundAdvSimd(ref s0, ref s1, ref s2, ref s3, 5, 6, 7, 4);
+                QuarterRoundAdvSimd(ref s0, ref s1, ref s2, ref s3, 10, 11, 8, 9);
+                QuarterRoundAdvSimd(ref s0, ref s1, ref s2, ref s3, 15, 12, 13, 14);
+            }
+
+            AdvSimd.Store(statePtr + 0, s0);
+            AdvSimd.Store(statePtr + 4, s1);
+            AdvSimd.Store(statePtr + 8, s2);
+            AdvSimd.Store(statePtr + 12, s3);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void QuarterRoundAvx2(ref Vector256<uint> s0, ref Vector256<uint> s1, int a, int b, int c, int d)
+    {
+        var va = GetElementAvx2(s0, s1, a);
+        var vb = GetElementAvx2(s0, s1, b);
+        var vc = GetElementAvx2(s0, s1, c);
+        var vd = GetElementAvx2(s0, s1, d);
+
+        vb = Avx2.Xor(vb, BitUtils.RotateLeftVector256(Avx2.Add(va, vd), 7));
+        vc = Avx2.Xor(vc, BitUtils.RotateLeftVector256(Avx2.Add(vb, va), 9));
+        vd = Avx2.Xor(vd, BitUtils.RotateLeftVector256(Avx2.Add(vc, vb), 13));
+        va = Avx2.Xor(va, BitUtils.RotateLeftVector256(Avx2.Add(vd, vc), 18));
+
+        SetElementAvx2(ref s0, ref s1, a, va);
+        SetElementAvx2(ref s0, ref s1, b, vb);
+        SetElementAvx2(ref s0, ref s1, c, vc);
+        SetElementAvx2(ref s0, ref s1, d, vd);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void QuarterRoundSse2(ref Vector128<uint> s0, ref Vector128<uint> s1, ref Vector128<uint> s2, ref Vector128<uint> s3, int a, int b, int c, int d)
+    {
+        var va = GetElementSse2(s0, s1, s2, s3, a);
+        var vb = GetElementSse2(s0, s1, s2, s3, b);
+        var vc = GetElementSse2(s0, s1, s2, s3, c);
+        var vd = GetElementSse2(s0, s1, s2, s3, d);
+
+        vb = Sse2.Xor(vb, BitUtils.RotateLeftVector128(Sse2.Add(va, vd), 7));
+        vc = Sse2.Xor(vc, BitUtils.RotateLeftVector128(Sse2.Add(vb, va), 9));
+        vd = Sse2.Xor(vd, BitUtils.RotateLeftVector128(Sse2.Add(vc, vb), 13));
+        va = Sse2.Xor(va, BitUtils.RotateLeftVector128(Sse2.Add(vd, vc), 18));
+
+        SetElementSse2(ref s0, ref s1, ref s2, ref s3, a, va);
+        SetElementSse2(ref s0, ref s1, ref s2, ref s3, b, vb);
+        SetElementSse2(ref s0, ref s1, ref s2, ref s3, c, vc);
+        SetElementSse2(ref s0, ref s1, ref s2, ref s3, d, vd);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void QuarterRoundAdvSimd(ref Vector128<uint> s0, ref Vector128<uint> s1, ref Vector128<uint> s2, ref Vector128<uint> s3, int a, int b, int c, int d)
+    {
+        var va = GetElementAdvSimd(s0, s1, s2, s3, a);
+        var vb = GetElementAdvSimd(s0, s1, s2, s3, b);
+        var vc = GetElementAdvSimd(s0, s1, s2, s3, c);
+        var vd = GetElementAdvSimd(s0, s1, s2, s3, d);
+
+        vb = AdvSimd.Xor(vb, BitUtils.RotateLeftAdvSimd(AdvSimd.Add(va, vd), 7));
+        vc = AdvSimd.Xor(vc, BitUtils.RotateLeftAdvSimd(AdvSimd.Add(vb, va), 9));
+        vd = AdvSimd.Xor(vd, BitUtils.RotateLeftAdvSimd(AdvSimd.Add(vc, vb), 13));
+        va = AdvSimd.Xor(va, BitUtils.RotateLeftAdvSimd(AdvSimd.Add(vd, vc), 18));
+
+        SetElementAdvSimd(ref s0, ref s1, ref s2, ref s3, a, va);
+        SetElementAdvSimd(ref s0, ref s1, ref s2, ref s3, b, vb);
+        SetElementAdvSimd(ref s0, ref s1, ref s2, ref s3, c, vc);
+        SetElementAdvSimd(ref s0, ref s1, ref s2, ref s3, d, vd);
+    }
+
+    // Helper methods for vector element access
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector256<uint> GetElementAvx2(Vector256<uint> s0, Vector256<uint> s1, int index)
+    {
+        var scalar = index < 8 ? s0.GetElement(index) : s1.GetElement(index - 8);
+        return Vector256.Create(scalar);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetElementAvx2(ref Vector256<uint> s0, ref Vector256<uint> s1, int index, Vector256<uint> value)
+    {
+        var scalar = value.GetElement(0);
+        if (index < 8)
+        {
+            s0 = s0.WithElement(index, scalar);
+        }
+        else
+        {
+            s1 = s1.WithElement(index - 8, scalar);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<uint> GetElementSse2(Vector128<uint> s0, Vector128<uint> s1, Vector128<uint> s2, Vector128<uint> s3, int index)
+    {
+        return index switch
+        {
+            < 4 => Vector128.Create(s0.GetElement(index)),
+            < 8 => Vector128.Create(s1.GetElement(index - 4)),
+            < 12 => Vector128.Create(s2.GetElement(index - 8)),
+            _ => Vector128.Create(s3.GetElement(index - 12))
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetElementSse2(ref Vector128<uint> s0, ref Vector128<uint> s1, ref Vector128<uint> s2, ref Vector128<uint> s3, int index, Vector128<uint> value)
+    {
+        var scalar = value.GetElement(0);
+        switch (index)
+        {
+            case < 4: s0 = s0.WithElement(index, scalar); break;
+            case < 8: s1 = s1.WithElement(index - 4, scalar); break;
+            case < 12: s2 = s2.WithElement(index - 8, scalar); break;
+            default: s3 = s3.WithElement(index - 12, scalar); break;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<uint> GetElementAdvSimd(Vector128<uint> s0, Vector128<uint> s1, Vector128<uint> s2, Vector128<uint> s3, int index)
+    {
+        return index switch
+        {
+            < 4 => Vector128.Create(s0.GetElement(index)),
+            < 8 => Vector128.Create(s1.GetElement(index - 4)),
+            < 12 => Vector128.Create(s2.GetElement(index - 8)),
+            _ => Vector128.Create(s3.GetElement(index - 12))
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetElementAdvSimd(ref Vector128<uint> s0, ref Vector128<uint> s1, ref Vector128<uint> s2, ref Vector128<uint> s3, int index, Vector128<uint> value)
+    {
+        var scalar = value.GetElement(0);
+        switch (index)
+        {
+            case < 4: s0 = s0.WithElement(index, scalar); break;
+            case < 8: s1 = s1.WithElement(index - 4, scalar); break;
+            case < 12: s2 = s2.WithElement(index - 8, scalar); break;
+            default: s3 = s3.WithElement(index - 12, scalar); break;
+        }
+    }
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void QuarterRound(ref uint a, ref uint b, ref uint c, ref uint d)

--- a/src/NaCl.Core/Base/Salsa20Base.cs
+++ b/src/NaCl.Core/Base/Salsa20Base.cs
@@ -70,7 +70,7 @@ public abstract class Salsa20Base : Snuffle
     {
         // See: http://cr.yp.to/snuffle/xsalsa-20081128.pdf under 2. Specification - Definition of HSalsa20
 
-        Span<uint> state = stackalloc uint[BLOCK_SIZE_IN_BYTES];
+        Span<uint> state = stackalloc uint[BLOCK_SIZE_IN_INTS];
 
         // Setting HSalsa20 initial state
         HSalsa20InitialState(state, nonce);

--- a/src/NaCl.Core/Base/Snuffle.cs
+++ b/src/NaCl.Core/Base/Snuffle.cs
@@ -10,14 +10,20 @@ using System.Security.Cryptography;
 /// <remarks>
 /// Variants of Snuffle have two differences: the size of the nonce and the block function that
 /// produces a key stream block from a key, a nonce, and a counter. Subclasses of this class
-/// specifying these two information by overriding <seealso cref="NaCl.Core.Base.Snuffle.NonceSizeInBytes" /> and <seealso cref="NaCl.Core.Base.Snuffle.BlockSizeInBytes" /> and <seealso cref="NaCl.Core.Base.Snuffle.ProcessKeyStreamBlock(ReadOnlySpan{byte},int,Span{byte})" />.
+/// specifying these two information by overriding <see cref="NaCl.Core.Base.Snuffle.NonceSizeInBytes" /> and <see cref="NaCl.Core.Base.Snuffle.BlockSizeInBytes" /> and <see cref="NaCl.Core.Base.Snuffle.ProcessKeyStreamBlock(ReadOnlySpan{byte},int,Span{byte})" />.
 ///
-/// Concrete implementations of this class are meant to be used to construct an AEAD with <seealso cref="NaCl.Core.Poly1305" />. The
-/// base class of these AEAD constructions is <seealso cref="NaCl.Core.Base.SnufflePoly1305" />.
-/// For example, <seealso cref="NaCl.Core.XChaCha20" /> is a subclass of this class and a
-/// concrete Snuffle implementation, and <seealso cref="NaCl.Core.XChaCha20Poly1305" /> is
-/// a subclass of <seealso cref="NaCl.Core.Base.SnufflePoly1305" /> and a concrete AEAD construction.
+/// Concrete implementations of this class are meant to be used to construct an AEAD with <see cref="NaCl.Core.Poly1305" />. The
+/// base class of these AEAD constructions is <see cref="NaCl.Core.Base.SnufflePoly1305" />.
+/// For example, <see cref="NaCl.Core.XChaCha20" /> is a subclass of this class and a
+/// concrete Snuffle implementation, and <see cref="NaCl.Core.XChaCha20Poly1305" /> is
+/// a subclass of <see cref="NaCl.Core.Base.SnufflePoly1305" /> and a concrete AEAD construction.
 /// </remarks>
+/// <seealso cref="NaCl.Core.Poly1305" />
+/// <seealso cref="NaCl.Core.Base.SnufflePoly1305" />
+/// <seealso cref="NaCl.Core.ChaCha20" />
+/// <seealso cref="NaCl.Core.ChaCha20Poly1305" />
+/// <seealso cref="NaCl.Core.XChaCha20" />
+/// <seealso cref="NaCl.Core.XChaCha20Poly1305" />
 public abstract class Snuffle
 {
     protected const int KEY_SIZE_IN_INTS = 8;
@@ -46,7 +52,7 @@ public abstract class Snuffle
     }
 
     /// <summary>
-    /// Process the key stream block <paramref name="block"/> from <paramref name="nonce"/> and <paramref name="counter"/>.
+    /// Process the key stream <paramref name="block"/> from <paramref name="nonce"/> and <paramref name="counter"/>.
     ///
     /// From this function, the Snuffle encryption function can be constructed using the counter
     /// mode of operation. For example, the ChaCha20 block function and how it can be used to
@@ -60,7 +66,7 @@ public abstract class Snuffle
 
     /// <summary>
     /// The size of the nonce in bytes.
-    /// Salsa20 uses a 8-byte (64-bit) nonce, ChaCha20 uses a 12-byte (96-bit) nonce, but XSalsa20 and XChaCha20 use a 24-byte (192-bit) nonce.
+    /// Salsa20 uses an 8-byte (64-bit) nonce, ChaCha20 uses a 12-byte (96-bit) nonce, but XSalsa20 and XChaCha20 use a 24-byte (192-bit) nonce.
     /// </summary>
     /// <returns>System.Int32.</returns>
     public abstract int NonceSizeInBytes { get; }

--- a/src/NaCl.Core/Base/Snuffle.cs
+++ b/src/NaCl.Core/Base/Snuffle.cs
@@ -30,16 +30,20 @@ using System.Runtime.Intrinsics.Arm;
 /// <seealso cref="NaCl.Core.ChaCha20Poly1305" />
 /// <seealso cref="NaCl.Core.XChaCha20" />
 /// <seealso cref="NaCl.Core.XChaCha20Poly1305" />
-public abstract class Snuffle
+public abstract class Snuffle : IDisposable
 {
+    private bool _disposed;
+    private readonly byte[] _key;
+
     protected const int KEY_SIZE_IN_INTS = 8;
     public const int KEY_SIZE_IN_BYTES = KEY_SIZE_IN_INTS * 4; // 32
     protected const int BLOCK_SIZE_IN_INTS = 16;
     public const int BLOCK_SIZE_IN_BYTES = BLOCK_SIZE_IN_INTS * 4; // 64
 
-    protected static uint[] SIGMA = new uint[] { 0x61707865, 0x3320646E, 0x79622D32, 0x6B206574 }; // "expand 32-byte k" (4 words constant: "expa", "nd 3", "2-by", and "te k")
+    protected static uint[] SIGMA = [0x61707865, 0x3320646E, 0x79622D32, 0x6B206574]; // "expand 32-byte k" (4 words constant: "expa", "nd 3", "2-by", and "te k")
 
-    protected readonly ReadOnlyMemory<byte> Key;
+    protected ReadOnlyMemory<byte> Key => _key;
+
     protected readonly int InitialCounter;
 
     /// <summary>
@@ -53,7 +57,8 @@ public abstract class Snuffle
         if (key.Length != KEY_SIZE_IN_BYTES)
             throw new CryptographicException($"The key length in bytes must be {KEY_SIZE_IN_BYTES}.");
 
-        Key = key;
+        // Make a private copy of the key for secure disposal
+        _key = key.ToArray();
         InitialCounter = initialCounter;
     }
 
@@ -89,10 +94,10 @@ public abstract class Snuffle
     /// <param name="nonce">The nonce associated with this message, which should be a unique value for every operation with the same key.</param>
     /// <param name="ciphertext">The byte array to receive the encrypted contents.</param>
     /// <exception cref="ArgumentException">Thrown when plaintext and ciphertext lengths don't match, or nonce length is invalid.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Encrypt(ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> nonce, Span<byte> ciphertext)
     {
-        //if (plaintext.Length > int.MaxValue - NonceSizeInBytes())
-        //    throw new ArgumentException($"The {nameof(plaintext)} is too long.");
+        ThrowIfDisposed();
 
         if (plaintext.Length != ciphertext.Length)
             throw new ArgumentException("The plaintext parameter and the ciphertext do not have the same length.");
@@ -110,8 +115,11 @@ public abstract class Snuffle
     /// <param name="nonce">The nonce associated with this message, which must match the value provided during encryption.</param>
     /// <param name="plaintext">The byte span to receive the decrypted contents.</param>
     /// <exception cref="ArgumentException">Thrown when plaintext and ciphertext lengths don't match, or nonce length is invalid.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Decrypt(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> nonce, Span<byte> plaintext)
     {
+        ThrowIfDisposed();
+
         if (plaintext.Length != ciphertext.Length)
             throw new ArgumentException("The ciphertext parameter and the plaintext do not have the same length.");
 
@@ -172,6 +180,53 @@ public abstract class Snuffle
     /// <param name="expected">The expected nonce length.</param>
     /// <returns>System.String.</returns>
     internal static string FormatNonceLengthExceptionMessage(string name, int actual, int expected) => $"{name} uses {expected * 8}-bit nonces, but got a {actual * 8}-bit nonce. The nonce length in bytes must be {expected}.";
+
+    /// <summary>
+    /// Throws an <see cref="ObjectDisposedException"/> if the instance has been disposed.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
+    protected void ThrowIfDisposed()
+    {
+#if NET7_0_OR_GREATER
+#pragma warning disable IDE0022 // Use expression body for method
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#pragma warning restore IDE0022 // Use expression body for method
+#else
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
+#endif
+    }
+
+    /// <summary>
+    /// Releases all resources used by the current instance of <see cref="Snuffle"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the <see cref="Snuffle"/> and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+
+        if (disposing)
+        {
+            // Clear the key from memory
+#if NET6_0_OR_GREATER
+            CryptographicOperations.ZeroMemory(_key);
+#else
+            Array.Clear(_key, 0, _key.Length);
+#endif
+        }
+
+        _disposed = true;
+    }
 
     /// <summary>
     /// XOR the specified output.

--- a/src/NaCl.Core/Base/Snuffle.cs
+++ b/src/NaCl.Core/Base/Snuffle.cs
@@ -2,7 +2,13 @@
 
 using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+#if NET6_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+#endif
 
 /// <summary>
 /// Abstract base class for XSalsa20, ChaCha20, XChaCha20 and their variants.
@@ -41,7 +47,7 @@ public abstract class Snuffle
     /// </summary>
     /// <param name="key">The secret key.</param>
     /// <param name="initialCounter">The initial counter.</param>
-    /// <exception cref="CryptographicException"></exception>
+    /// <exception cref="CryptographicException">Thrown when the key length is invalid.</exception>
     protected Snuffle(ReadOnlyMemory<byte> key, int initialCounter)
     {
         if (key.Length != KEY_SIZE_IN_BYTES)
@@ -82,7 +88,7 @@ public abstract class Snuffle
     /// <param name="plaintext">The content to encrypt.</param>
     /// <param name="nonce">The nonce associated with this message, which should be a unique value for every operation with the same key.</param>
     /// <param name="ciphertext">The byte array to receive the encrypted contents.</param>
-    /// <exception cref="CryptographicException">plaintext or nonce</exception>
+    /// <exception cref="ArgumentException">Thrown when plaintext and ciphertext lengths don't match, or nonce length is invalid.</exception>
     public void Encrypt(ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> nonce, Span<byte> ciphertext)
     {
         //if (plaintext.Length > int.MaxValue - NonceSizeInBytes())
@@ -103,7 +109,7 @@ public abstract class Snuffle
     /// <param name="ciphertext">The encrypted content to decrypt.</param>
     /// <param name="nonce">The nonce associated with this message, which must match the value provided during encryption.</param>
     /// <param name="plaintext">The byte span to receive the decrypted contents.</param>
-    /// <exception cref="CryptographicException">ciphertext or nonce.</exception>
+    /// <exception cref="ArgumentException">Thrown when plaintext and ciphertext lengths don't match, or nonce length is invalid.</exception>
     public void Decrypt(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> nonce, Span<byte> plaintext)
     {
         if (plaintext.Length != ciphertext.Length)
@@ -176,16 +182,73 @@ public abstract class Snuffle
     /// <param name="len">The length.</param>
     /// <param name="offset">The output's starting offset.</param>
     /// <param name="curBlock">The current block number.</param>
-    /// <exception cref="CryptographicException">The combination of blocks, offsets and length to be XORed is out-of-bonds.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void Xor(Span<byte> output, ReadOnlySpan<byte> input, ReadOnlySpan<byte> block, int len, int offset, int curBlock)
     {
         var blockOffset = curBlock * BlockSizeInBytes;
 
-        // Since is not called directly from outside, there's no need to check
-        //if (len < 0 || offset < 0 || curBlock < 0 || output.Length < len || (input.Length - blockOffset) < len || block.Length < len)
-        //    throw new CryptographicException("The combination of blocks, offsets and length to be XORed is out-of-bonds.");
-
-        for (var i = 0; i < len; i++)
-            output[i + offset + blockOffset] = (byte)(input[i + blockOffset] ^ block[i]);
+#if NET6_0_OR_GREATER
+        XorVectorized(output, input, block, len, offset + blockOffset, blockOffset);
+#else
+        XorScalar(output, input, block, len, offset + blockOffset, blockOffset);
+#endif
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void XorScalar(Span<byte> output, ReadOnlySpan<byte> input, ReadOnlySpan<byte> block, int len, int outputOffset, int inputOffset)
+    {
+        for (var i = 0; i < len; i++)
+            output[outputOffset + i] = (byte)(input[inputOffset + i] ^ block[i]);
+    }
+
+#if NET6_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void XorVectorized(Span<byte> output, ReadOnlySpan<byte> input, ReadOnlySpan<byte> block, int len, int outputOffset, int inputOffset)
+    {
+        var i = 0;
+
+        fixed (byte* outputPtr = output)
+        fixed (byte* inputPtr = input)
+        fixed (byte* blockPtr = block)
+        {
+            if (Avx2.IsSupported && len >= Vector256<byte>.Count)
+            {
+                var vectorSize = Vector256<byte>.Count; // 32 bytes
+                for (; i + vectorSize <= len; i += vectorSize)
+                {
+                    var inputVec = Avx.LoadVector256(inputPtr + inputOffset + i);
+                    var blockVec = Avx.LoadVector256(blockPtr + i);
+                    var result = Avx2.Xor(inputVec, blockVec);
+                    Avx.Store(outputPtr + outputOffset + i, result);
+                }
+            }
+            else if (Sse2.IsSupported && len >= Vector128<byte>.Count)
+            {
+                var vectorSize = Vector128<byte>.Count; // 16 bytes
+                for (; i + vectorSize <= len; i += vectorSize)
+                {
+                    var inputVec = Sse2.LoadVector128(inputPtr + inputOffset + i);
+                    var blockVec = Sse2.LoadVector128(blockPtr + i);
+                    var result = Sse2.Xor(inputVec, blockVec);
+                    Sse2.Store(outputPtr + outputOffset + i, result);
+                }
+            }
+            else if (AdvSimd.IsSupported && len >= Vector128<byte>.Count)
+            {
+                var vectorSize = Vector128<byte>.Count; // 16 bytes
+                for (; i + vectorSize <= len; i += vectorSize)
+                {
+                    var inputVec = AdvSimd.LoadVector128(inputPtr + inputOffset + i);
+                    var blockVec = AdvSimd.LoadVector128(blockPtr + i);
+                    var result = AdvSimd.Xor(inputVec, blockVec);
+                    AdvSimd.Store(outputPtr + outputOffset + i, result);
+                }
+            }
+        }
+
+        // Handle remaining bytes with scalar XOR
+        for (; i < len; i++)
+            output[outputOffset + i] = (byte)(input[inputOffset + i] ^ block[i]);
+    }
+#endif
 }

--- a/src/NaCl.Core/Base/SnufflePoly1305.cs
+++ b/src/NaCl.Core/Base/SnufflePoly1305.cs
@@ -11,6 +11,8 @@ using Internal;
 ///
 /// This implementation produces ciphertext with the following format: {nonce || actual_ciphertext || tag} and only decrypts the same format.
 /// </summary>
+/// <seealso cref="NaCl.Core.ChaCha20Poly1305" />
+/// <seealso cref="NaCl.Core.XChaCha20Poly1305" />
 public abstract class SnufflePoly1305
 {
     private readonly Snuffle _snuffle;

--- a/src/NaCl.Core/Base/SnufflePoly1305.cs
+++ b/src/NaCl.Core/Base/SnufflePoly1305.cs
@@ -1,6 +1,7 @@
 ﻿namespace NaCl.Core.Base;
 
 using System;
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
@@ -17,6 +18,7 @@ public abstract class SnufflePoly1305
 {
     private readonly Snuffle _snuffle;
     private readonly Snuffle _macKeySnuffle;
+    private const int StackallocThreshold = 1024; // 1KB threshold
     public const string AEAD_EXCEPTION_INVALID_TAG = "The tag value could not be verified, or the decryption operation otherwise failed."; // "AEAD Bad Tag Exception";
 
     /// <summary>
@@ -67,11 +69,25 @@ public abstract class SnufflePoly1305
 
         var aadPaddedLen = GetPaddedLength(associatedData, Poly1305.MAC_TAG_SIZE_IN_BYTES);
         var ciphertextPaddedLen = GetPaddedLength(ciphertext, Poly1305.MAC_TAG_SIZE_IN_BYTES);
-        var macData = new Span<byte>(new byte[aadPaddedLen + ciphertextPaddedLen + Poly1305.MAC_TAG_SIZE_IN_BYTES]);
+        var macDataSize = aadPaddedLen + ciphertextPaddedLen + Poly1305.MAC_TAG_SIZE_IN_BYTES;
 
-        PrepareMacDataRfc8439(macData, associatedData, aadPaddedLen, ciphertext, ciphertextPaddedLen);
-
-        Poly1305.ComputeMac(GetMacKey(nonce), macData, tag);
+        // Use stackalloc for small buffers, pooled memory for larger ones
+        if (macDataSize <= StackallocThreshold)
+        {
+            Span<byte> macData = stackalloc byte[macDataSize];
+            macData.Clear(); // Ensure padding is zero
+            PrepareMacDataRfc8439(macData, associatedData, aadPaddedLen, ciphertext, ciphertextPaddedLen);
+            ComputeMacWithPooledKey(nonce, macData, tag);
+        }
+        else
+        {
+            // Use pooled memory for larger buffers to avoid stack overflow
+            using var macDataOwner = MemoryPool<byte>.Shared.Rent(macDataSize);
+            var macData = macDataOwner.Memory.Span[..macDataSize];
+            macData.Clear(); // Ensure padding is zero
+            PrepareMacDataRfc8439(macData, associatedData, aadPaddedLen, ciphertext, ciphertextPaddedLen);
+            ComputeMacWithPooledKey(nonce, macData, tag);
+        }
     }
 
     /// <summary>
@@ -104,10 +120,25 @@ public abstract class SnufflePoly1305
         {
             var aadPaddedLen = GetPaddedLength(associatedData, Poly1305.MAC_TAG_SIZE_IN_BYTES);
             var ciphertextPaddedLen = GetPaddedLength(ciphertext, Poly1305.MAC_TAG_SIZE_IN_BYTES);
-            var macData = new Span<byte>(new byte[aadPaddedLen + ciphertextPaddedLen + Poly1305.MAC_TAG_SIZE_IN_BYTES]);
+            var macDataSize = aadPaddedLen + ciphertextPaddedLen + Poly1305.MAC_TAG_SIZE_IN_BYTES;
 
-            PrepareMacDataRfc8439(macData, associatedData, aadPaddedLen, ciphertext, ciphertextPaddedLen);
-            Poly1305.VerifyMac(GetMacKey(nonce), macData, tag);
+            // Use stackalloc for small buffers, pooled memory for larger ones
+            if (macDataSize <= StackallocThreshold)
+            {
+                Span<byte> macData = stackalloc byte[macDataSize];
+                macData.Clear(); // Ensure padding is zero
+                PrepareMacDataRfc8439(macData, associatedData, aadPaddedLen, ciphertext, ciphertextPaddedLen);
+                VerifyMacWithPooledKey(nonce, macData, tag);
+            }
+            else
+            {
+                // Use pooled memory for larger buffers to avoid stack overflow
+                using var macDataOwner = MemoryPool<byte>.Shared.Rent(macDataSize);
+                var macData = macDataOwner.Memory.Span[..macDataSize];
+                macData.Clear(); // Ensure padding is zero
+                PrepareMacDataRfc8439(macData, associatedData, aadPaddedLen, ciphertext, ciphertextPaddedLen);
+                VerifyMacWithPooledKey(nonce, macData, tag);
+            }
         }
         catch (CryptographicException ex) when (ex.Message.Contains("length"))
         {
@@ -123,9 +154,54 @@ public abstract class SnufflePoly1305
 
     /// <summary>
     /// The MAC key is the first 32 bytes of the first key stream block.
+    /// Uses pooled memory to avoid allocations.
+    /// </summary>
+    /// <param name="nonce">The nonce.</param>
+    /// <param name="macKey">The span to receive the MAC key.</param>
+    private void GetMacKeyPooled(ReadOnlySpan<byte> nonce, Span<byte> macKey)
+    {
+        using var blockOwner = MemoryPool<byte>.Shared.Rent(_macKeySnuffle.BlockSizeInBytes);
+        var firstBlock = blockOwner.Memory.Span[.._macKeySnuffle.BlockSizeInBytes];
+        _macKeySnuffle.ProcessKeyStreamBlock(nonce, 0, firstBlock);
+
+        firstBlock[..Poly1305.MAC_KEY_SIZE_IN_BYTES].CopyTo(macKey);
+    }
+
+    /// <summary>
+    /// Computes MAC using pooled memory for the key.
+    /// </summary>
+    /// <param name="nonce">The nonce.</param>
+    /// <param name="macData">The MAC data.</param>
+    /// <param name="tag">The computed tag.</param>
+    private void ComputeMacWithPooledKey(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> macData, Span<byte> tag)
+    {
+        Span<byte> macKey = stackalloc byte[Poly1305.MAC_KEY_SIZE_IN_BYTES];
+        GetMacKeyPooled(nonce, macKey);
+        Poly1305.ComputeMac(macKey, macData, tag);
+        macKey.Clear(); // Clear sensitive data
+    }
+
+    /// <summary>
+    /// Verifies MAC using pooled memory for the key.
+    /// </summary>
+    /// <param name="nonce">The nonce.</param>
+    /// <param name="macData">The MAC data.</param>
+    /// <param name="tag">The tag to verify.</param>
+    private void VerifyMacWithPooledKey(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> macData, ReadOnlySpan<byte> tag)
+    {
+        Span<byte> macKey = stackalloc byte[Poly1305.MAC_KEY_SIZE_IN_BYTES];
+        GetMacKeyPooled(nonce, macKey);
+        Poly1305.VerifyMac(macKey, macData, tag);
+        macKey.Clear(); // Clear sensitive data
+    }
+
+    /// <summary>
+    /// The MAC key is the first 32 bytes of the first key stream block.
     /// </summary>
     /// <param name="nonce">The nonce.</param>
     /// <returns>System.Byte[].</returns>
+    [ExcludeFromCodeCoverage]
+    [Obsolete("Use ComputeMacWithPooledKey or VerifyMacWithPooledKey to avoid allocations")]
     private Span<byte> GetMacKey(ReadOnlySpan<byte> nonce)
     {
         Span<byte> firstBlock = new byte[_macKeySnuffle.BlockSizeInBytes];

--- a/src/NaCl.Core/Base/SnufflePoly1305.cs
+++ b/src/NaCl.Core/Base/SnufflePoly1305.cs
@@ -14,12 +14,13 @@ using Internal;
 /// </summary>
 /// <seealso cref="NaCl.Core.ChaCha20Poly1305" />
 /// <seealso cref="NaCl.Core.XChaCha20Poly1305" />
-public abstract class SnufflePoly1305
+public abstract class SnufflePoly1305 : IDisposable
 {
     private readonly Snuffle _snuffle;
     private readonly Snuffle _macKeySnuffle;
     private const int StackallocThreshold = 1024; // 1KB threshold
     public const string AEAD_EXCEPTION_INVALID_TAG = "The tag value could not be verified, or the decryption operation otherwise failed."; // "AEAD Bad Tag Exception";
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SnufflePoly1305"/> class.
@@ -47,7 +48,8 @@ public abstract class SnufflePoly1305
     /// <param name="ciphertext">The byte array to receive the encrypted contents.</param>
     /// <param name="tag">The byte array to receive the generated authentication tag.</param>
     /// <param name="associatedData">Extra data associated with this message, which must also be provided during decryption.</param>
-    /// <exception cref="CryptographicException">plaintext or nonce</exception>
+    /// <exception cref="CryptographicException">Thrown when encryption fails.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Encrypt(byte[] nonce, byte[] plaintext, byte[] ciphertext, byte[] tag, byte[] associatedData = default)
         => Encrypt((ReadOnlySpan<byte>)nonce, (ReadOnlySpan<byte>)plaintext, (Span<byte>)ciphertext, (Span<byte>)tag, (ReadOnlySpan<byte>)associatedData);
 
@@ -59,11 +61,11 @@ public abstract class SnufflePoly1305
     /// <param name="ciphertext">The byte span to receive the encrypted contents.</param>
     /// <param name="tag">The byte span to receive the generated authentication tag.</param>
     /// <param name="associatedData">Extra data associated with this message, which must also be provided during decryption.</param>
-    /// <exception cref="CryptographicException">plaintext or nonce</exception>
+    /// <exception cref="CryptographicException">Thrown when encryption fails.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Encrypt(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> plaintext, Span<byte> ciphertext, Span<byte> tag, ReadOnlySpan<byte> associatedData = default)
     {
-        //if (plaintext.Length > int.MaxValue - _snuffle.NonceSizeInBytes() - Poly1305.MAC_TAG_SIZE_IN_BYTES)
-        //    throw new ArgumentException($"The {nameof(plaintext)} is too long.");
+        ThrowIfDisposed();
 
         _snuffle.Encrypt(plaintext, nonce, ciphertext);
 
@@ -99,6 +101,7 @@ public abstract class SnufflePoly1305
     /// <param name="plaintext">The byte array to receive the decrypted contents.</param>
     /// <param name="associatedData">Extra data associated with this message, which must match the value provided during encryption.</param>
     /// <exception cref="CryptographicException">The tag value could not be verified, or the decryption operation otherwise failed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Decrypt(byte[] nonce, byte[] ciphertext, byte[] tag, byte[] plaintext, byte[] associatedData = default)
         => Decrypt((ReadOnlySpan<byte>)nonce, (ReadOnlySpan<byte>)ciphertext, (ReadOnlySpan<byte>)tag, (Span<byte>)plaintext, (ReadOnlySpan<byte>)associatedData);
 
@@ -111,8 +114,11 @@ public abstract class SnufflePoly1305
     /// <param name="plaintext">The byte span to receive the decrypted contents.</param>
     /// <param name="associatedData">Extra data associated with this message, which must match the value provided during encryption.</param>
     /// <exception cref="CryptographicException">The tag value could not be verified, or the decryption operation otherwise failed.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
     public void Decrypt(ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> tag, Span<byte> plaintext, ReadOnlySpan<byte> associatedData = default)
     {
+        ThrowIfDisposed();
+
         if (nonce.IsEmpty || nonce.Length != _snuffle.NonceSizeInBytes)
             throw new ArgumentException(Snuffle.FormatNonceLengthExceptionMessage(_snuffle.GetType().Name, nonce.Length, _snuffle.NonceSizeInBytes));
 
@@ -196,49 +202,6 @@ public abstract class SnufflePoly1305
     }
 
     /// <summary>
-    /// The MAC key is the first 32 bytes of the first key stream block.
-    /// </summary>
-    /// <param name="nonce">The nonce.</param>
-    /// <returns>System.Byte[].</returns>
-    [ExcludeFromCodeCoverage]
-    [Obsolete("Use ComputeMacWithPooledKey or VerifyMacWithPooledKey to avoid allocations")]
-    private Span<byte> GetMacKey(ReadOnlySpan<byte> nonce)
-    {
-        Span<byte> firstBlock = new byte[_macKeySnuffle.BlockSizeInBytes];
-        _macKeySnuffle.ProcessKeyStreamBlock(nonce, 0, firstBlock);
-
-        return firstBlock[..Poly1305.MAC_KEY_SIZE_IN_BYTES];
-    }
-
-    /// <summary>
-    /// Prepares the input to MAC, following RFC 8439, section 2.8.
-    /// </summary>
-    /// <param name="aad">The associated data.</param>
-    /// <param name="ciphertext">The ciphertext.</param>
-    /// <returns>System.Byte[].</returns>
-#if !NETSTANDARD1_6
-    [ExcludeFromCodeCoverage] // It will be removed along with the obsolete methods
-#endif
-    private byte[] GetMacDataRfc8439(ReadOnlySpan<byte> aad, ReadOnlySpan<byte> ciphertext)
-    {
-        var aadPaddedLen = GetPaddedLength(aad, Poly1305.MAC_TAG_SIZE_IN_BYTES);
-        var ciphertextLen = ciphertext.Length;
-        var ciphertextPaddedLen = GetPaddedLength(ciphertext, Poly1305.MAC_TAG_SIZE_IN_BYTES);
-
-        var macData = new byte[aadPaddedLen + ciphertextPaddedLen + Poly1305.MAC_TAG_SIZE_IN_BYTES];
-
-        // Mac Text
-        Array.Copy(aad.ToArray(), macData, aad.Length);
-        Array.Copy(ciphertext.ToArray(), 0, macData, aadPaddedLen, ciphertextLen);
-
-        // Mac Length
-        SetMacLength(macData, aadPaddedLen + ciphertextPaddedLen, aad.Length);
-        SetMacLength(macData, aadPaddedLen + ciphertextPaddedLen + sizeof(ulong), ciphertextLen);
-
-        return macData;
-    }
-
-    /// <summary>
     /// Prepares the input to MAC, following RFC 8439, section 2.8.
     /// </summary>
     /// <param name="mac">The resulting mac content.</param>
@@ -260,4 +223,48 @@ public abstract class SnufflePoly1305
     private static int GetPaddedLength(ReadOnlySpan<byte> input, int size) => (input.Length % size == 0) ? input.Length : (input.Length + size - input.Length % size);
 
     private static void SetMacLength(Span<byte> macData, int offset, int value) => ArrayUtils.StoreUInt64LittleEndian(macData, offset, (ulong)value);
+
+    /// <summary>
+    /// Throws an <see cref="ObjectDisposedException"/> if the instance has been disposed.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has been disposed.</exception>
+    private void ThrowIfDisposed()
+    {
+#if NET7_0_OR_GREATER
+#pragma warning disable IDE0022 // Use expression body for method
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#pragma warning restore IDE0022 // Use expression body for method
+#else
+        if (_disposed)
+            throw new ObjectDisposedException(GetType().Name);
+#endif
+    }
+
+    /// <summary>
+    /// Releases all resources used by the current instance of <see cref="SnufflePoly1305"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the <see cref="SnufflePoly1305"/> and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+
+        if (disposing)
+        {
+            // Dispose the underlying Snuffle instances which will clear their keys
+            _snuffle.Dispose();
+            _macKeySnuffle.Dispose();
+        }
+
+        _disposed = true;
+    }
 }

--- a/src/NaCl.Core/ChaCha20.cs
+++ b/src/NaCl.Core/ChaCha20.cs
@@ -7,13 +7,13 @@ using Base;
 using Internal;
 
 /// <summary>
-/// A stream cipher based on RFC 8439 (previously RFC 7539) (i.e., uses 96-bit random nonces).
-/// https://tools.ietf.org/html/rfc8439#section-2.8
-/// https://tools.ietf.org/html/rfc7539#section-2.8
+/// A stream cipher based on <a href="https://tools.ietf.org/html/rfc8439#section-2.8">RFC 8439</a> (previously <a href="https://tools.ietf.org/html/rfc7539#section-2.8">RFC 7539</a>) (i.e., uses 96-bit random nonces).
 ///
 /// This cipher is meant to be used to construct an AEAD with Poly1305.
 /// </summary>
 /// <seealso cref="NaCl.Core.Base.ChaCha20Base" />
+/// <seealso href="https://tools.ietf.org/html/rfc8439#section-2.8">RFC 8439</seealso>
+/// <seealso href="https://tools.ietf.org/html/rfc7539#section-2.8">RFC 7539</seealso>
 public class ChaCha20 : ChaCha20Base
 {
     public const int NONCE_SIZE_IN_BYTES = 12;

--- a/src/NaCl.Core/ChaCha20Poly1305.cs
+++ b/src/NaCl.Core/ChaCha20Poly1305.cs
@@ -7,7 +7,9 @@ using Base;
 /// <summary>
 /// ChaCha20-Poly1305 AEAD construction, as described in <a href="https://tools.ietf.org/html/rfc8439#section-2.8">RFC 8439, section 2.8</a>.
 /// </summary>
+/// <seealso cref="NaCl.Core.ChaCha20" />
 /// <seealso cref="NaCl.Core.Base.SnufflePoly1305" />
+/// <seealso cref="NaCl.Core.Poly1305" />
 public sealed class ChaCha20Poly1305 : SnufflePoly1305
 {
     /// <summary>

--- a/src/NaCl.Core/Internal/ArrayUtils.cs
+++ b/src/NaCl.Core/Internal/ArrayUtils.cs
@@ -23,7 +23,7 @@ internal static class ArrayUtils
     /// <param name="buf">The output buffer.</param>
     /// <param name="offset">The output offset.</param>
     /// <param name="value">The input value.</param>
-    public static void StoreUI32LittleEndian(Span<byte> buf, int offset, uint value)
+    public static void StoreUInt32LittleEndian(Span<byte> buf, int offset, uint value)
         => BinaryPrimitives.WriteUInt32LittleEndian(buf.Slice(offset + 0, sizeof(int)), value);
 
     /// <summary>

--- a/src/NaCl.Core/Internal/ArrayUtils.cs
+++ b/src/NaCl.Core/Internal/ArrayUtils.cs
@@ -2,6 +2,12 @@
 
 using System;
 using System.Buffers.Binary;
+#if NET6_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.CompilerServices;
+#endif
 
 internal static class ArrayUtils
 {
@@ -67,8 +73,36 @@ internal static class ArrayUtils
     /// <param name="size">The parts to split the input buffer.</param>
     public static void StoreArrayUInt32LittleEndian(Span<byte> output, int offset, ReadOnlySpan<uint> input, int size)
     {
-        var len = sizeof(int);
+#if NET6_0_OR_GREATER
+        if (Avx2.IsSupported && size >= 8)
+        {
+            StoreArrayUInt32LittleEndianAvx2(output, offset, input, size);
+            return;
+        }
+        if (Sse2.IsSupported && size >= 4)
+        {
+            StoreArrayUInt32LittleEndianSse2(output, offset, input, size);
+            return;
+        }
+        if (AdvSimd.IsSupported && size >= 4)
+        {
+            StoreArrayUInt32LittleEndianAdvSimd(output, offset, input, size);
+            return;
+        }
+#endif
+        StoreArrayUInt32LittleEndianScalar(output, offset, input, size);
+    }
 
+    /// <summary>
+    /// Stores the byte array split in n size parts into 4 bytes and places it in the output buffer using scalar operations.
+    /// </summary>
+    /// <param name="output">The output buffer.</param>
+    /// <param name="offset">The starting offset.</param>
+    /// <param name="input">The input buffer.</param>
+    /// <param name="size">The parts to split the input buffer.</param>
+    private static void StoreArrayUInt32LittleEndianScalar(Span<byte> output, int offset, ReadOnlySpan<uint> input, int size)
+    {
+        var len = sizeof(int);
         var start = offset + 0;
         for (var i = 0; i < size; i++)
         {
@@ -76,6 +110,209 @@ internal static class ArrayUtils
             start += len;
         }
     }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Stores the byte array using AVX2 intrinsics for vectorized operations.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void StoreArrayUInt32LittleEndianAvx2(Span<byte> output, int offset, ReadOnlySpan<uint> input, int size)
+    {
+        fixed (byte* outputPtr = &output[offset])
+        fixed (uint* inputPtr = input)
+        {
+            var i = 0;
+            var vectorSize = Vector256<uint>.Count; // 8 elements
+            var vectorSizeBytes = vectorSize * sizeof(uint); // 32 bytes
+
+            // Process 8 uint32s (32 bytes) at a time with AVX2
+            for (; i + vectorSize <= size; i += vectorSize)
+            {
+                var vec = Avx.LoadVector256(inputPtr + i);
+                Avx.Store(outputPtr + i * sizeof(uint), vec.AsByte());
+            }
+
+            // Handle remaining elements with scalar operations
+            for (; i < size; i++)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    output.Slice(offset + i * sizeof(uint), sizeof(uint)), 
+                    input[i]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stores the byte array using SSE2 intrinsics for vectorized operations.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void StoreArrayUInt32LittleEndianSse2(Span<byte> output, int offset, ReadOnlySpan<uint> input, int size)
+    {
+        fixed (byte* outputPtr = &output[offset])
+        fixed (uint* inputPtr = input)
+        {
+            var i = 0;
+            var vectorSize = Vector128<uint>.Count; // 4 elements
+
+            // Process 4 uint32s (16 bytes) at a time with SSE2
+            for (; i + vectorSize <= size; i += vectorSize)
+            {
+                var vec = Sse2.LoadVector128(inputPtr + i);
+                Sse2.Store(outputPtr + i * sizeof(uint), vec.AsByte());
+            }
+
+            // Handle remaining elements with scalar operations
+            for (; i < size; i++)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    output.Slice(offset + i * sizeof(uint), sizeof(uint)), 
+                    input[i]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stores the byte array using ARM AdvSIMD intrinsics for vectorized operations.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void StoreArrayUInt32LittleEndianAdvSimd(Span<byte> output, int offset, ReadOnlySpan<uint> input, int size)
+    {
+        fixed (byte* outputPtr = &output[offset])
+        fixed (uint* inputPtr = input)
+        {
+            var i = 0;
+            var vectorSize = Vector128<uint>.Count; // 4 elements
+
+            // Process 4 uint32s (16 bytes) at a time with AdvSIMD
+            for (; i + vectorSize <= size; i += vectorSize)
+            {
+                var vec = AdvSimd.LoadVector128(inputPtr + i);
+                AdvSimd.Store(outputPtr + i * sizeof(uint), vec.AsByte());
+            }
+
+            // Handle remaining elements with scalar operations
+            for (; i < size; i++)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(
+                    output.Slice(offset + i * sizeof(uint), sizeof(uint)), 
+                    input[i]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads multiple uint32 values from a byte buffer using vectorized operations when possible.
+    /// </summary>
+    /// <param name="input">The input byte buffer.</param>
+    /// <param name="offset">The starting offset in the input buffer.</param>
+    /// <param name="output">The output uint32 buffer.</param>
+    /// <param name="size">The number of uint32 values to load.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void LoadArrayUInt32LittleEndian(ReadOnlySpan<byte> input, int offset, Span<uint> output, int size)
+    {
+        if (Avx2.IsSupported && size >= 8)
+        {
+            LoadArrayUInt32LittleEndianAvx2(input, offset, output, size);
+            return;
+        }
+        if (Sse2.IsSupported && size >= 4)
+        {
+            LoadArrayUInt32LittleEndianSse2(input, offset, output, size);
+            return;
+        }
+        if (AdvSimd.IsSupported && size >= 4)
+        {
+            LoadArrayUInt32LittleEndianAdvSimd(input, offset, output, size);
+            return;
+        }
+        
+        LoadArrayUInt32LittleEndianScalar(input, offset, output, size);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void LoadArrayUInt32LittleEndianScalar(ReadOnlySpan<byte> input, int offset, Span<uint> output, int size)
+    {
+        for (var i = 0; i < size; i++)
+        {
+            output[i] = BinaryPrimitives.ReadUInt32LittleEndian(input.Slice(offset + i * sizeof(uint), sizeof(uint)));
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void LoadArrayUInt32LittleEndianAvx2(ReadOnlySpan<byte> input, int offset, Span<uint> output, int size)
+    {
+        fixed (byte* inputPtr = &input[offset])
+        fixed (uint* outputPtr = output)
+        {
+            var i = 0;
+            var vectorSize = Vector256<uint>.Count; // 8 elements
+
+            // Process 8 uint32s (32 bytes) at a time with AVX2
+            for (; i + vectorSize <= size; i += vectorSize)
+            {
+                var vec = Avx.LoadVector256(inputPtr + i * sizeof(uint));
+                Avx.Store(outputPtr + i, vec.AsUInt32());
+            }
+
+            // Handle remaining elements with scalar operations
+            for (; i < size; i++)
+            {
+                output[i] = BinaryPrimitives.ReadUInt32LittleEndian(
+                    input.Slice(offset + i * sizeof(uint), sizeof(uint)));
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void LoadArrayUInt32LittleEndianSse2(ReadOnlySpan<byte> input, int offset, Span<uint> output, int size)
+    {
+        fixed (byte* inputPtr = &input[offset])
+        fixed (uint* outputPtr = output)
+        {
+            var i = 0;
+            var vectorSize = Vector128<uint>.Count; // 4 elements
+
+            // Process 4 uint32s (16 bytes) at a time with SSE2
+            for (; i + vectorSize <= size; i += vectorSize)
+            {
+                var vec = Sse2.LoadVector128(inputPtr + i * sizeof(uint));
+                Sse2.Store(outputPtr + i, vec.AsUInt32());
+            }
+
+            // Handle remaining elements with scalar operations
+            for (; i < size; i++)
+            {
+                output[i] = BinaryPrimitives.ReadUInt32LittleEndian(
+                    input.Slice(offset + i * sizeof(uint), sizeof(uint)));
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void LoadArrayUInt32LittleEndianAdvSimd(ReadOnlySpan<byte> input, int offset, Span<uint> output, int size)
+    {
+        fixed (byte* inputPtr = &input[offset])
+        fixed (uint* outputPtr = output)
+        {
+            var i = 0;
+            var vectorSize = Vector128<uint>.Count; // 4 elements
+
+            // Process 4 uint32s (16 bytes) at a time with AdvSIMD
+            for (; i + vectorSize <= size; i += vectorSize)
+            {
+                var vec = AdvSimd.LoadVector128(inputPtr + i * sizeof(uint));
+                AdvSimd.Store(outputPtr + i, vec.AsUInt32());
+            }
+
+            // Handle remaining elements with scalar operations
+            for (; i < size; i++)
+            {
+                output[i] = BinaryPrimitives.ReadUInt32LittleEndian(
+                    input.Slice(offset + i * sizeof(uint), sizeof(uint)));
+            }
+        }
+    }
+#endif
 
     #endregion
 }

--- a/src/NaCl.Core/Internal/BitUtils.cs
+++ b/src/NaCl.Core/Internal/BitUtils.cs
@@ -1,6 +1,12 @@
 ﻿namespace NaCl.Core.Internal;
 
+using System;
 using System.Runtime.CompilerServices;
+#if NET6_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+#endif
 
 internal static class BitUtils
 {
@@ -35,4 +41,54 @@ internal static class BitUtils
         return (value << offset) | (value >> (64 - offset));
 #endif
     }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Rotates the specified Vector128 value left by 16 bits.
+    /// </summary>
+    /// <param name="value">The value to rotate.</param>
+    /// <param name="offset">The number of bits to rotate by.</param>
+    /// <returns>The rotated value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector128<uint> RotateLeftVector128(Vector128<uint> value, int offset) => offset switch
+    {
+        16 => Sse2.Or(Sse2.ShiftLeftLogical(value, 16), Sse2.ShiftRightLogical(value, 16)),
+        12 => Sse2.Or(Sse2.ShiftLeftLogical(value, 12), Sse2.ShiftRightLogical(value, 20)),
+        8 => Sse2.Or(Sse2.ShiftLeftLogical(value, 8), Sse2.ShiftRightLogical(value, 24)),
+        7 => Sse2.Or(Sse2.ShiftLeftLogical(value, 7), Sse2.ShiftRightLogical(value, 25)),
+        _ => throw new ArgumentException($"Unsupported rotation offset: {offset}")
+    };
+
+    /// <summary>
+    /// Rotates the specified Vector256 value left by the specified number of bits.
+    /// </summary>
+    /// <param name="value">The value to rotate.</param>
+    /// <param name="offset">The number of bits to rotate by.</param>
+    /// <returns>The rotated value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector256<uint> RotateLeftVector256(Vector256<uint> value, int offset) => offset switch
+    {
+        16 => Avx2.Or(Avx2.ShiftLeftLogical(value, 16), Avx2.ShiftRightLogical(value, 16)),
+        12 => Avx2.Or(Avx2.ShiftLeftLogical(value, 12), Avx2.ShiftRightLogical(value, 20)),
+        8 => Avx2.Or(Avx2.ShiftLeftLogical(value, 8), Avx2.ShiftRightLogical(value, 24)),
+        7 => Avx2.Or(Avx2.ShiftLeftLogical(value, 7), Avx2.ShiftRightLogical(value, 25)),
+        _ => throw new ArgumentException($"Unsupported rotation offset: {offset}")
+    };
+
+    /// <summary>
+    /// Rotates the specified Vector128 value left by the specified number of bits using ARM AdvSIMD.
+    /// </summary>
+    /// <param name="value">The value to rotate.</param>
+    /// <param name="offset">The number of bits to rotate by.</param>
+    /// <returns>The rotated value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector128<uint> RotateLeftAdvSimd(Vector128<uint> value, int offset) => offset switch
+    {
+        16 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 16), AdvSimd.ShiftRightLogical(value, 16)),
+        12 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 12), AdvSimd.ShiftRightLogical(value, 20)),
+        8 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 8), AdvSimd.ShiftRightLogical(value, 24)),
+        7 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 7), AdvSimd.ShiftRightLogical(value, 25)),
+        _ => throw new ArgumentException($"Unsupported rotation offset: {offset}")
+    };
+#endif
 }

--- a/src/NaCl.Core/Internal/BitUtils.cs
+++ b/src/NaCl.Core/Internal/BitUtils.cs
@@ -52,10 +52,15 @@ internal static class BitUtils
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Vector128<uint> RotateLeftVector128(Vector128<uint> value, int offset) => offset switch
     {
+        // ChaCha20 rotations
         16 => Sse2.Or(Sse2.ShiftLeftLogical(value, 16), Sse2.ShiftRightLogical(value, 16)),
         12 => Sse2.Or(Sse2.ShiftLeftLogical(value, 12), Sse2.ShiftRightLogical(value, 20)),
         8 => Sse2.Or(Sse2.ShiftLeftLogical(value, 8), Sse2.ShiftRightLogical(value, 24)),
         7 => Sse2.Or(Sse2.ShiftLeftLogical(value, 7), Sse2.ShiftRightLogical(value, 25)),
+        // Salsa20 rotations
+        18 => Sse2.Or(Sse2.ShiftLeftLogical(value, 18), Sse2.ShiftRightLogical(value, 14)),
+        13 => Sse2.Or(Sse2.ShiftLeftLogical(value, 13), Sse2.ShiftRightLogical(value, 19)),
+        9 => Sse2.Or(Sse2.ShiftLeftLogical(value, 9), Sse2.ShiftRightLogical(value, 23)),
         _ => throw new ArgumentException($"Unsupported rotation offset: {offset}")
     };
 
@@ -68,10 +73,15 @@ internal static class BitUtils
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Vector256<uint> RotateLeftVector256(Vector256<uint> value, int offset) => offset switch
     {
+        // ChaCha20 rotations
         16 => Avx2.Or(Avx2.ShiftLeftLogical(value, 16), Avx2.ShiftRightLogical(value, 16)),
         12 => Avx2.Or(Avx2.ShiftLeftLogical(value, 12), Avx2.ShiftRightLogical(value, 20)),
         8 => Avx2.Or(Avx2.ShiftLeftLogical(value, 8), Avx2.ShiftRightLogical(value, 24)),
         7 => Avx2.Or(Avx2.ShiftLeftLogical(value, 7), Avx2.ShiftRightLogical(value, 25)),
+        // Salsa20 rotations
+        18 => Avx2.Or(Avx2.ShiftLeftLogical(value, 18), Avx2.ShiftRightLogical(value, 14)),
+        13 => Avx2.Or(Avx2.ShiftLeftLogical(value, 13), Avx2.ShiftRightLogical(value, 19)),
+        9 => Avx2.Or(Avx2.ShiftLeftLogical(value, 9), Avx2.ShiftRightLogical(value, 23)),
         _ => throw new ArgumentException($"Unsupported rotation offset: {offset}")
     };
 
@@ -84,10 +94,15 @@ internal static class BitUtils
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Vector128<uint> RotateLeftAdvSimd(Vector128<uint> value, int offset) => offset switch
     {
+        // ChaCha20 rotations
         16 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 16), AdvSimd.ShiftRightLogical(value, 16)),
         12 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 12), AdvSimd.ShiftRightLogical(value, 20)),
         8 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 8), AdvSimd.ShiftRightLogical(value, 24)),
         7 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 7), AdvSimd.ShiftRightLogical(value, 25)),
+        // Salsa20 rotations
+        18 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 18), AdvSimd.ShiftRightLogical(value, 14)),
+        13 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 13), AdvSimd.ShiftRightLogical(value, 19)),
+        9 => AdvSimd.Or(AdvSimd.ShiftLeftLogical(value, 9), AdvSimd.ShiftRightLogical(value, 23)),
         _ => throw new ArgumentException($"Unsupported rotation offset: {offset}")
     };
 #endif

--- a/src/NaCl.Core/Internal/CryptoBytes.cs
+++ b/src/NaCl.Core/Internal/CryptoBytes.cs
@@ -4,7 +4,7 @@ using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
-public static class CryptoBytes
+internal static class CryptoBytes
 {
     public static byte[] Combine(params byte[][] arrays)
     {
@@ -129,21 +129,21 @@ public static class CryptoBytes
     //
     // An explanation of the weird bit fiddling:
     //
-    // 1. `bytes[i] >> 4` extracts the high nibble of a byte  
+    // 1. `bytes[i] >> 4` extracts the high nibble of a byte
     //   `bytes[i] & 0xF` extracts the low nibble of a byte
-    // 2. `b - 10`  
-    //    is `< 0` for values `b < 10`, which will become a decimal digit  
+    // 2. `b - 10`
+    //    is `< 0` for values `b < 10`, which will become a decimal digit
     //    is `>= 0` for values `b > 10`, which will become a letter from `A` to `F`.
     // 3. Using `i >> 31` on a signed 32 bit integer extracts the sign, thanks to sign extension.
     //    It will be `-1` for `i < 0` and `0` for `i >= 0`.
     // 4. Combining 2) and 3), shows that `(b-10)>>31` will be `0` for letters and `-1` for digits.
     // 5. Looking at the case for letters, the last summand becomes `0`, and `b` is in the range 10 to 15. We want to map it to `A`(65) to `F`(70), which implies adding 55 (`'A'-10`).
-    // 6. Looking at the case for digits, we want to adapt the last summand so it maps `b` from the range 0 to 9 to the range `0`(48) to `9`(57). This means it needs to become -7 (`'0' - 55`).  
+    // 6. Looking at the case for digits, we want to adapt the last summand so it maps `b` from the range 0 to 9 to the range `0`(48) to `9`(57). This means it needs to become -7 (`'0' - 55`).
     // Now we could just multiply with 7. But since -1 is represented by all bits being 1, we can instead use `& -7` since `(0 & -7) == 0` and `(-1 & -7) == -7`.
     //
     // Some further considerations:
     //
-    // * I didn't use a second loop variable to index into `c`, since measurement shows that calculating it from `i` is cheaper. 
+    // * I didn't use a second loop variable to index into `c`, since measurement shows that calculating it from `i` is cheaper.
     // * Using exactly `i < bytes.Length` as upper bound of the loop allows the JITter to eliminate bounds checks on `bytes[i]`, so I chose that variant.
     // * Making `b` an int avoids unnecessary conversions from and to byte.
     public static string ToHexStringUpper(byte[] data)

--- a/src/NaCl.Core/Internal/CryptoBytes.cs
+++ b/src/NaCl.Core/Internal/CryptoBytes.cs
@@ -1,8 +1,11 @@
-﻿namespace NaCl.Core.Internal;
+namespace NaCl.Core.Internal;
 
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
+#if NET6_0_OR_GREATER
+using System.Security.Cryptography;
+#endif
 
 internal static class CryptoBytes
 {
@@ -25,7 +28,11 @@ internal static class CryptoBytes
         if (x.Length != y.Length)
             throw new ArgumentException("x.Length must equal y.Length");
 
+#if NET6_0_OR_GREATER
+        return CryptographicOperations.FixedTimeEquals(x, y);
+#else
         return InternalConstantTimeEquals(x, 0, y, 0, x.Length) != 0;
+#endif
     }
 
     public static bool ConstantTimeEquals(ArraySegment<byte> x, ArraySegment<byte> y)

--- a/src/NaCl.Core/NaCl.Core.csproj
+++ b/src/NaCl.Core/NaCl.Core.csproj
@@ -55,7 +55,7 @@
 
   <ItemGroup Label="Package References for Windows" Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'net48' OR $(TargetFramework) == 'net481'">
     <PackageReference Include="IndexRange" Version="1.0.3" />
-    <PackageReference Include="System.Memory" Version="4.6.2" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup Label="Package References for Windows" Condition="$(TargetFramework) == 'net45'">

--- a/src/NaCl.Core/NaCl.Core.csproj
+++ b/src/NaCl.Core/NaCl.Core.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard2.0;netstandard2.1;netcoreapp3.1;net45;net48;net481;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard2.0;netstandard2.1;net45;net48;net481;net6.0;net8.0;net9.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NaCl.Core/NaCl.Core.csproj
+++ b/src/NaCl.Core/NaCl.Core.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard2.0;netstandard2.1;net45;net48;net481;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard2.0;netstandard2.1;net45;net48;net481;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/NaCl.Core/Poly1305.cs
+++ b/src/NaCl.Core/Poly1305.cs
@@ -262,10 +262,10 @@ public static class Poly1305
         f3 = ((h3 >> 18) | (h4 << 8)) + (ulong)internalKey[7];
 
         // mac = (h + pad) % (2^128)
-        ArrayUtils.StoreUI32LittleEndian(tag, 0, (uint)f0); f1 += (f0 >> 32);
-        ArrayUtils.StoreUI32LittleEndian(tag, 4, (uint)f1); f2 += (f1 >> 32);
-        ArrayUtils.StoreUI32LittleEndian(tag, 8, (uint)f2); f3 += (f2 >> 32);
-        ArrayUtils.StoreUI32LittleEndian(tag, 12, (uint)f3);
+        ArrayUtils.StoreUInt32LittleEndian(tag, 0, (uint)f0); f1 += (f0 >> 32);
+        ArrayUtils.StoreUInt32LittleEndian(tag, 4, (uint)f1); f2 += (f1 >> 32);
+        ArrayUtils.StoreUInt32LittleEndian(tag, 8, (uint)f2); f3 += (f2 >> 32);
+        ArrayUtils.StoreUInt32LittleEndian(tag, 12, (uint)f3);
     }
 
     /// <summary>

--- a/src/NaCl.Core/Poly1305.cs
+++ b/src/NaCl.Core/Poly1305.cs
@@ -18,8 +18,8 @@ using Internal;
 /// </summary>
 public static class Poly1305
 {
-    public static int MAC_TAG_SIZE_IN_BYTES = 16;
-    public static int MAC_KEY_SIZE_IN_BYTES = 32;
+    public const int MAC_TAG_SIZE_IN_BYTES = 16;
+    public const int MAC_KEY_SIZE_IN_BYTES = 32;
     public const string MAC_EXCEPTION_INVALID = "Invalid MAC";
 
     private static void GetLastBlock(ReadOnlySpan<byte> buf, int idx, Span<byte> output)
@@ -329,24 +329,6 @@ public static class Poly1305
         FinalizeTagAvx2(hVec, keyVec, tag);
     }
 
-    /// <summary>
-    /// Computes the authentication <paramref name="tag"/> using SSE2 intrinsics.
-    /// </summary>
-    private static void ComputeMacSse2(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> tag)
-    {
-        // For SSE2, we can still use some optimizations but fallback to scalar for complex operations
-        ComputeMacScalar(key, data, tag);
-    }
-
-    /// <summary>
-    /// Computes the authentication <paramref name="tag"/> using ARM AdvSIMD intrinsics.
-    /// </summary>
-    private static void ComputeMacAdvSimd(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> tag)
-    {
-        // Similar to SSE2, ARM AdvSIMD optimization would need careful implementation
-        ComputeMacScalar(key, data, tag);
-    }
-
     private static void ComputeBlockScalar(ref Vector256<uint> hVec, Vector256<uint> blockVec, Vector256<uint> rVec, Vector256<uint> sVec, bool lastBlock)
     {
         // Extract current hash state
@@ -447,24 +429,308 @@ public static class Poly1305
         ArrayUtils.StoreUInt32LittleEndian(tag, 8, (uint)f2); f3 += (f2 >> 32);
         ArrayUtils.StoreUInt32LittleEndian(tag, 12, (uint)f3);
     }
+
+    /// <summary>
+    /// Computes the authentication <paramref name="tag"/> using SSE2 intrinsics.
+    /// Uses SIMD for data loading and final operations while maintaining scalar polynomial arithmetic.
+    /// </summary>
+    private static unsafe void ComputeMacSse2(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> tag)
+    {
+        if (key.Length != MAC_KEY_SIZE_IN_BYTES)
+            throw new CryptographicException($"The key length in bytes must be {MAC_KEY_SIZE_IN_BYTES}.");
+
+        if (tag.Length != MAC_TAG_SIZE_IN_BYTES)
+            throw new CryptographicException($"The tag length in bytes must be {MAC_TAG_SIZE_IN_BYTES}.");
+
+        // Load key using SIMD
+        fixed (byte* keyPtr = key)
+        {
+            var keyLo = Sse2.LoadVector128((uint*)keyPtr);       // First 16 bytes (r)
+            var keyHi = Sse2.LoadVector128((uint*)(keyPtr + 16)); // Last 16 bytes (s/pad)
+
+            // Extract and clamp r values
+            var t0 = keyLo.GetElement(0);
+            var t1 = keyLo.GetElement(1);
+            var t2 = keyLo.GetElement(2);
+            var t3 = keyLo.GetElement(3);
+
+            var r0 = t0 & 0x3ffffff; t0 >>= 26; t0 |= t1 << 6;
+            var r1 = t0 & 0x3ffff03; t1 >>= 20; t1 |= t2 << 12;
+            var r2 = t1 & 0x3ffc0ff; t2 >>= 14; t2 |= t3 << 18;
+            var r3 = t2 & 0x3f03fff; t3 >>= 8;
+            var r4 = t3 & 0x00fffff;
+
+            var s1 = r1 * 5;
+            var s2 = r2 * 5;
+            var s3 = r3 * 5;
+            var s4 = r4 * 5;
+
+            // Initialize hash state
+            uint h0 = 0, h1 = 0, h2 = 0, h3 = 0, h4 = 0;
+
+            // Process data blocks
+            Span<byte> block = stackalloc byte[MAC_KEY_SIZE_IN_BYTES];
+            fixed (byte* dataPtr = data)
+            fixed (byte* blockPtr = block)
+            {
+                for (var i = 0; i < data.Length; i += MAC_TAG_SIZE_IN_BYTES)
+                {
+                    var lastBlock = (data.Length - i) < MAC_TAG_SIZE_IN_BYTES;
+                    Vector128<uint> dataVec;
+
+                    if (lastBlock)
+                    {
+                        GetLastBlock(data, i, block);
+                        dataVec = Sse2.LoadVector128((uint*)blockPtr);
+                        block.Clear();
+                    }
+                    else
+                    {
+                        // Use SIMD load for aligned/unaligned data
+                        dataVec = Sse2.LoadVector128((uint*)(dataPtr + i));
+                    }
+
+                    // Extract block values from vector
+                    t0 = dataVec.GetElement(0);
+                    t1 = dataVec.GetElement(1);
+                    t2 = dataVec.GetElement(2);
+                    t3 = dataVec.GetElement(3);
+
+                    // Add block to accumulator
+                    h0 += t0 & 0x3ffffff;
+                    h1 += (uint)(((((ulong)t1 << 32) | t0) >> 26) & 0x3ffffff);
+                    h2 += (uint)(((((ulong)t2 << 32) | t1) >> 20) & 0x3ffffff);
+                    h3 += (uint)(((((ulong)t3 << 32) | t2) >> 14) & 0x3ffffff);
+                    h4 = lastBlock ? h4 + (t3 >> 8) : h4 + ((t3 >> 8) | (1u << 24));
+
+                    // Polynomial multiplication d = r * h
+                    var tt0 = (ulong)h0 * r0 + (ulong)h1 * s4 + (ulong)h2 * s3 + (ulong)h3 * s2 + (ulong)h4 * s1;
+                    var tt1 = (ulong)h0 * r1 + (ulong)h1 * r0 + (ulong)h2 * s4 + (ulong)h3 * s3 + (ulong)h4 * s2;
+                    var tt2 = (ulong)h0 * r2 + (ulong)h1 * r1 + (ulong)h2 * r0 + (ulong)h3 * s4 + (ulong)h4 * s3;
+                    var tt3 = (ulong)h0 * r3 + (ulong)h1 * r2 + (ulong)h2 * r1 + (ulong)h3 * r0 + (ulong)h4 * s4;
+                    var tt4 = (ulong)h0 * r4 + (ulong)h1 * r3 + (ulong)h2 * r2 + (ulong)h3 * r1 + (ulong)h4 * r0;
+
+                    // Partial reduction mod 2^130-5
+                    unchecked
+                    {
+                        h0 = (uint)tt0 & 0x3ffffff; var c = (tt0 >> 26);
+                        tt1 += c; h1 = (uint)tt1 & 0x3ffffff; var b = (uint)(tt1 >> 26);
+                        tt2 += b; h2 = (uint)tt2 & 0x3ffffff; b = (uint)(tt2 >> 26);
+                        tt3 += b; h3 = (uint)tt3 & 0x3ffffff; b = (uint)(tt3 >> 26);
+                        tt4 += b; h4 = (uint)tt4 & 0x3ffffff; b = (uint)(tt4 >> 26);
+                        h0 += b * 5;
+                    }
+                }
+            }
+
+            // Finalize using SIMD for final operations
+            FinalizeTagSse2(h0, h1, h2, h3, h4, keyHi, tag);
+        }
+    }
+
+    private static unsafe void FinalizeTagSse2(uint h0, uint h1, uint h2, uint h3, uint h4, Vector128<uint> padVec, Span<byte> tag)
+    {
+        // Final reduction mod 2^130-5
+        var b = h0 >> 26; h0 &= 0x3ffffff;
+        h1 += b; b = h1 >> 26; h1 &= 0x3ffffff;
+        h2 += b; b = h2 >> 26; h2 &= 0x3ffffff;
+        h3 += b; b = h3 >> 26; h3 &= 0x3ffffff;
+        h4 += b; b = h4 >> 26; h4 &= 0x3ffffff;
+        h0 += b * 5;
+
+        // Compute h - p
+        var g0 = h0 + 5; b = g0 >> 26; g0 &= 0x3ffffff;
+        var g1 = h1 + b; b = g1 >> 26; g1 &= 0x3ffffff;
+        var g2 = h2 + b; b = g2 >> 26; g2 &= 0x3ffffff;
+        var g3 = h3 + b; b = g3 >> 26; g3 &= 0x3ffffff;
+        var g4 = unchecked(h4 + b - (1u << 26));
+
+        // Select h if h < p, or h - p if h >= p
+        b = (g4 >> 31) - 1;
+        var nb = ~b;
+        h0 = (h0 & nb) | (g0 & b);
+        h1 = (h1 & nb) | (g1 & b);
+        h2 = (h2 & nb) | (g2 & b);
+        h3 = (h3 & nb) | (g3 & b);
+        h4 = (h4 & nb) | (g4 & b);
+
+        // h = h % (2^128) + pad
+        var f0 = ((h0) | (h1 << 26)) + (ulong)padVec.GetElement(0);
+        var f1 = ((h1 >> 6) | (h2 << 20)) + (ulong)padVec.GetElement(1);
+        var f2 = ((h2 >> 12) | (h3 << 14)) + (ulong)padVec.GetElement(2);
+        var f3 = ((h3 >> 18) | (h4 << 8)) + (ulong)padVec.GetElement(3);
+
+        // Propagate carries and store using SIMD
+        f1 += (f0 >> 32);
+        f2 += (f1 >> 32);
+        f3 += (f2 >> 32);
+
+        var result = Vector128.Create((uint)f0, (uint)f1, (uint)f2, (uint)f3);
+        fixed (byte* tagPtr = tag)
+        {
+            Sse2.Store((uint*)tagPtr, result);
+        }
+    }
+
+    /// <summary>
+    /// Computes the authentication <paramref name="tag"/> using ARM AdvSIMD intrinsics.
+    /// Uses SIMD for data loading and final operations while maintaining scalar polynomial arithmetic.
+    /// </summary>
+    private static unsafe void ComputeMacAdvSimd(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> tag)
+    {
+        if (key.Length != MAC_KEY_SIZE_IN_BYTES)
+            throw new CryptographicException($"The key length in bytes must be {MAC_KEY_SIZE_IN_BYTES}.");
+
+        if (tag.Length != MAC_TAG_SIZE_IN_BYTES)
+            throw new CryptographicException($"The tag length in bytes must be {MAC_TAG_SIZE_IN_BYTES}.");
+
+        // Load key using SIMD
+        fixed (byte* keyPtr = key)
+        {
+            var keyLo = AdvSimd.LoadVector128((uint*)keyPtr);       // First 16 bytes (r)
+            var keyHi = AdvSimd.LoadVector128((uint*)(keyPtr + 16)); // Last 16 bytes (s/pad)
+
+            // Extract and clamp r values
+            var t0 = keyLo.GetElement(0);
+            var t1 = keyLo.GetElement(1);
+            var t2 = keyLo.GetElement(2);
+            var t3 = keyLo.GetElement(3);
+
+            var r0 = t0 & 0x3ffffff; t0 >>= 26; t0 |= t1 << 6;
+            var r1 = t0 & 0x3ffff03; t1 >>= 20; t1 |= t2 << 12;
+            var r2 = t1 & 0x3ffc0ff; t2 >>= 14; t2 |= t3 << 18;
+            var r3 = t2 & 0x3f03fff; t3 >>= 8;
+            var r4 = t3 & 0x00fffff;
+
+            var s1 = r1 * 5;
+            var s2 = r2 * 5;
+            var s3 = r3 * 5;
+            var s4 = r4 * 5;
+
+            // Initialize hash state
+            uint h0 = 0, h1 = 0, h2 = 0, h3 = 0, h4 = 0;
+
+            // Process data blocks
+            Span<byte> block = stackalloc byte[MAC_KEY_SIZE_IN_BYTES];
+            fixed (byte* dataPtr = data)
+            fixed (byte* blockPtr = block)
+            {
+                for (var i = 0; i < data.Length; i += MAC_TAG_SIZE_IN_BYTES)
+                {
+                    var lastBlock = (data.Length - i) < MAC_TAG_SIZE_IN_BYTES;
+                    Vector128<uint> dataVec;
+
+                    if (lastBlock)
+                    {
+                        GetLastBlock(data, i, block);
+                        dataVec = AdvSimd.LoadVector128((uint*)blockPtr);
+                        block.Clear();
+                    }
+                    else
+                    {
+                        // Use SIMD load for data
+                        dataVec = AdvSimd.LoadVector128((uint*)(dataPtr + i));
+                    }
+
+                    // Extract block values from vector
+                    t0 = dataVec.GetElement(0);
+                    t1 = dataVec.GetElement(1);
+                    t2 = dataVec.GetElement(2);
+                    t3 = dataVec.GetElement(3);
+
+                    // Add block to accumulator
+                    h0 += t0 & 0x3ffffff;
+                    h1 += (uint)(((((ulong)t1 << 32) | t0) >> 26) & 0x3ffffff);
+                    h2 += (uint)(((((ulong)t2 << 32) | t1) >> 20) & 0x3ffffff);
+                    h3 += (uint)(((((ulong)t3 << 32) | t2) >> 14) & 0x3ffffff);
+                    h4 = lastBlock ? h4 + (t3 >> 8) : h4 + ((t3 >> 8) | (1u << 24));
+
+                    // Polynomial multiplication d = r * h
+                    var tt0 = (ulong)h0 * r0 + (ulong)h1 * s4 + (ulong)h2 * s3 + (ulong)h3 * s2 + (ulong)h4 * s1;
+                    var tt1 = (ulong)h0 * r1 + (ulong)h1 * r0 + (ulong)h2 * s4 + (ulong)h3 * s3 + (ulong)h4 * s2;
+                    var tt2 = (ulong)h0 * r2 + (ulong)h1 * r1 + (ulong)h2 * r0 + (ulong)h3 * s4 + (ulong)h4 * s3;
+                    var tt3 = (ulong)h0 * r3 + (ulong)h1 * r2 + (ulong)h2 * r1 + (ulong)h3 * r0 + (ulong)h4 * s4;
+                    var tt4 = (ulong)h0 * r4 + (ulong)h1 * r3 + (ulong)h2 * r2 + (ulong)h3 * r1 + (ulong)h4 * r0;
+
+                    // Partial reduction mod 2^130-5
+                    unchecked
+                    {
+                        h0 = (uint)tt0 & 0x3ffffff; var c = (tt0 >> 26);
+                        tt1 += c; h1 = (uint)tt1 & 0x3ffffff; var b = (uint)(tt1 >> 26);
+                        tt2 += b; h2 = (uint)tt2 & 0x3ffffff; b = (uint)(tt2 >> 26);
+                        tt3 += b; h3 = (uint)tt3 & 0x3ffffff; b = (uint)(tt3 >> 26);
+                        tt4 += b; h4 = (uint)tt4 & 0x3ffffff; b = (uint)(tt4 >> 26);
+                        h0 += b * 5;
+                    }
+                }
+            }
+
+            // Finalize using SIMD for final operations
+            FinalizeTagAdvSimd(h0, h1, h2, h3, h4, keyHi, tag);
+        }
+    }
+
+    private static unsafe void FinalizeTagAdvSimd(uint h0, uint h1, uint h2, uint h3, uint h4, Vector128<uint> padVec, Span<byte> tag)
+    {
+        // Final reduction mod 2^130-5
+        var b = h0 >> 26; h0 &= 0x3ffffff;
+        h1 += b; b = h1 >> 26; h1 &= 0x3ffffff;
+        h2 += b; b = h2 >> 26; h2 &= 0x3ffffff;
+        h3 += b; b = h3 >> 26; h3 &= 0x3ffffff;
+        h4 += b; b = h4 >> 26; h4 &= 0x3ffffff;
+        h0 += b * 5;
+
+        // Compute h - p
+        var g0 = h0 + 5; b = g0 >> 26; g0 &= 0x3ffffff;
+        var g1 = h1 + b; b = g1 >> 26; g1 &= 0x3ffffff;
+        var g2 = h2 + b; b = g2 >> 26; g2 &= 0x3ffffff;
+        var g3 = h3 + b; b = g3 >> 26; g3 &= 0x3ffffff;
+        var g4 = unchecked(h4 + b - (1u << 26));
+
+        // Select h if h < p, or h - p if h >= p
+        b = (g4 >> 31) - 1;
+        var nb = ~b;
+        h0 = (h0 & nb) | (g0 & b);
+        h1 = (h1 & nb) | (g1 & b);
+        h2 = (h2 & nb) | (g2 & b);
+        h3 = (h3 & nb) | (g3 & b);
+        h4 = (h4 & nb) | (g4 & b);
+
+        // h = h % (2^128) + pad
+        var f0 = ((h0) | (h1 << 26)) + (ulong)padVec.GetElement(0);
+        var f1 = ((h1 >> 6) | (h2 << 20)) + (ulong)padVec.GetElement(1);
+        var f2 = ((h2 >> 12) | (h3 << 14)) + (ulong)padVec.GetElement(2);
+        var f3 = ((h3 >> 18) | (h4 << 8)) + (ulong)padVec.GetElement(3);
+
+        // Propagate carries and store using SIMD
+        f1 += (f0 >> 32);
+        f2 += (f1 >> 32);
+        f3 += (f2 >> 32);
+
+        var result = Vector128.Create((uint)f0, (uint)f1, (uint)f2, (uint)f3);
+        fixed (byte* tagPtr = tag)
+        {
+            AdvSimd.Store((uint*)tagPtr, result);
+        }
+    }
 #endif
 
     /// <summary>
-    /// Verifies the authentication <paramref name="mac"/> using the specified <paramref name="key"/> and <paramref name="data"/>.
+    /// Verifies the authentication tag using the specified <paramref name="key"/> and <paramref name="data"/>.
     /// </summary>
     /// <param name="key">The secret key.</param>
     /// <param name="data">The data.</param>
-    /// <param name="tag">The authentication tag.</param>
-    /// <exception cref="CryptographicException"></exception>
+    /// <param name="tag">The authentication tag to verify.</param>
+    /// <exception cref="CryptographicException">Thrown when the key length is invalid, tag length is invalid, or the tag verification fails.</exception>
     public static void VerifyMac(byte[] key, byte[] data, byte[] tag) => VerifyMac((ReadOnlySpan<byte>)key, (ReadOnlySpan<byte>)data, (ReadOnlySpan<byte>)tag);
 
     /// <summary>
-    /// Verifies the authentication <paramref name="mac"/> using the specified <paramref name="key"/> and <paramref name="data"/>.
+    /// Verifies the authentication tag using the specified <paramref name="key"/> and <paramref name="data"/>.
     /// </summary>
     /// <param name="key">The secret key.</param>
     /// <param name="data">The data.</param>
-    /// <param name="tag">The authentication tag.</param>
-    /// <exception cref="CryptographicException"></exception>
+    /// <param name="tag">The authentication tag to verify.</param>
+    /// <exception cref="CryptographicException">Thrown when the key length is invalid, tag length is invalid, or the tag verification fails.</exception>
     public static void VerifyMac(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, ReadOnlySpan<byte> tag)
     {
         if (tag.Length != MAC_TAG_SIZE_IN_BYTES)

--- a/src/NaCl.Core/Poly1305.cs
+++ b/src/NaCl.Core/Poly1305.cs
@@ -2,6 +2,11 @@
 
 using System;
 using System.Security.Cryptography;
+#if NET6_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+#endif
 
 using Internal;
 
@@ -17,77 +22,19 @@ public static class Poly1305
     public static int MAC_KEY_SIZE_IN_BYTES = 32;
     public const string MAC_EXCEPTION_INVALID = "Invalid MAC";
 
-    /*
-    private static long Load32(ReadOnlySpan<byte> buf, int idx)
-    {
-        //return ByteIntegerConverter.LoadLittleEndian32(buf, idx);
-        return ((buf[idx] & 0xff)
-                | ((buf[idx + 1] & 0xff) << 8)
-                | ((buf[idx + 2] & 0xff) << 16)
-                | ((buf[idx + 3] & 0xff) << 24))
-                & 0xffffffffL;
-    }
-
-    private static long Load26(ReadOnlySpan<byte> buf, int idx, int shift) => (Load32(buf, idx) >> shift) & 0x3ffffff;
-
-    private static void ToByteArray(byte[] output, long num, int idx)
-    {
-        for (var i = 0; i < 4; i++, num >>= 8)
-            output[idx + i] = (byte)(num & 0xff);
-    }
-    */
-
-    // private static void Fill<T>(T[] array, int start, int end, T value)
-    // {
-    //     /*
-    //      * Shouldn't run into any exception since is not exposed to public
-    //      *
-    //     if (array is null)
-    //         throw new ArgumentNullException(nameof(array));
-
-    //     if (start < 0 || start >= end)
-    //         throw new ArgumentOutOfRangeException(nameof(start));
-
-    //     if (end > array.Length)
-    //         throw new ArgumentOutOfRangeException(nameof(end));
-    //     */
-
-    //     for (var i = start; i < end; i++)
-    //         array[i] = value;
-    // }
-
-    /*
-    private static void ProcessBlock(byte[] output, ReadOnlySpan<byte> buf, int idx)
+    private static void GetLastBlock(ReadOnlySpan<byte> buf, int idx, Span<byte> output)
     {
         var copyCount = Math.Min(MAC_TAG_SIZE_IN_BYTES, buf.Length - idx);
-        //Array.Copy(buf.ToArray(), idx, output, 0, copyCount);
 
+        // Clear the output buffer first (ensure padding is zero)
+        output.Clear();
+
+        // Copy the remaining data
         for (var i = 0; i < copyCount; i++)
             output[i] = buf[idx + i];
 
+        // Add the padding bit
         output[copyCount] = 1;
-
-        if (copyCount != MAC_TAG_SIZE_IN_BYTES)
-            Fill(output, copyCount + 1, output.Length, (byte)0);
-    }
-    */
-
-    private static byte[] GetLastBlock(ReadOnlySpan<byte> buf, int idx)
-    {
-        var output = new byte[MAC_KEY_SIZE_IN_BYTES];
-
-        var copyCount = Math.Min(MAC_TAG_SIZE_IN_BYTES, buf.Length - idx);
-        //Array.Copy(buf.ToArray(), idx, output, 0, copyCount);
-
-        for (var i = 0; i < copyCount; i++)
-            output[i] = buf[idx + i];
-
-        output[copyCount] = 1;
-
-        //if (copyCount != MAC_TAG_SIZE_IN_BYTES)
-        //    Fill(output, copyCount + 1, output.Length, (byte)0);
-
-        return output;
     }
 
     /// <summary>
@@ -133,6 +80,36 @@ public static class Poly1305
     /// <returns>System.Byte[].</returns>
     /// <exception cref="CryptographicException">The key length in bytes must be {MAC_KEY_SIZE_IN_BYTES}</exception>
     public static void ComputeMac(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> tag)
+    {
+#if NET6_0_OR_GREATER
+        if (Avx2.IsSupported)
+        {
+            ComputeMacAvx2(key, data, tag);
+            return;
+        }
+        if (Sse2.IsSupported)
+        {
+            ComputeMacSse2(key, data, tag);
+            return;
+        }
+        if (AdvSimd.IsSupported)
+        {
+            ComputeMacAdvSimd(key, data, tag);
+            return;
+        }
+#endif
+        ComputeMacScalar(key, data, tag);
+    }
+
+    /// <summary>
+    /// Computes the authentication <paramref name="tag"/> into a destination buffer using the specified <paramref name="key"/> and <paramref name="data"/> using scalar operations.
+    /// </summary>
+    /// <param name="key">The secret key.</param>
+    /// <param name="data">The input to compute the authentication tag.</param>
+    /// <param name="tag">The byte span to receive the generated authentication tag.</param>
+    /// <returns>System.Byte[].</returns>
+    /// <exception cref="CryptographicException">The key length in bytes must be {MAC_KEY_SIZE_IN_BYTES}</exception>
+    private static void ComputeMacScalar(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> tag)
     {
         if (key.Length != MAC_KEY_SIZE_IN_BYTES)
             throw new CryptographicException($"The key length in bytes must be {MAC_KEY_SIZE_IN_BYTES}.");
@@ -183,19 +160,20 @@ public static class Poly1305
         var s4 = r4 * 5;
 
         // Process blocks
+        Span<byte> block = stackalloc byte[MAC_KEY_SIZE_IN_BYTES]; // Move stackalloc out of loop
         for (var i = 0; i < data.Length; i += MAC_TAG_SIZE_IN_BYTES)
         {
             var lastBlock = (data.Length - i) < MAC_TAG_SIZE_IN_BYTES;
             if (lastBlock)
             {
-                var block = GetLastBlock(data, i); // TODO: Remove allocation
+                GetLastBlock(data, i, block);
 
                 t0 = ArrayUtils.LoadUInt32LittleEndian(block, 0);
                 t1 = ArrayUtils.LoadUInt32LittleEndian(block, 4);
                 t2 = ArrayUtils.LoadUInt32LittleEndian(block, 8);
                 t3 = ArrayUtils.LoadUInt32LittleEndian(block, 12);
 
-                CryptoBytes.Wipe(block);
+                block.Clear(); // Clear sensitive data
             }
             else
             {
@@ -268,151 +246,208 @@ public static class Poly1305
         ArrayUtils.StoreUInt32LittleEndian(tag, 12, (uint)f3);
     }
 
+#if NET6_0_OR_GREATER
     /// <summary>
-    /// Computes the mac value using the specified key and data.
+    /// Computes the authentication <paramref name="tag"/> using AVX2 intrinsics.
     /// </summary>
-    /// <param name="key">The key.</param>
-    /// <param name="data">The data.</param>
-    /// <returns>System.Byte[].</returns>
-    /// <exception cref="CryptographicException">The key length in bytes must be {MAC_KEY_SIZE_IN_BYTES}</exception>
-    /*
-    public static byte[] ComputeMacLegacy(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data)
+    private static void ComputeMacAvx2(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> tag)
     {
         if (key.Length != MAC_KEY_SIZE_IN_BYTES)
             throw new CryptographicException($"The key length in bytes must be {MAC_KEY_SIZE_IN_BYTES}.");
 
-        long h0 = 0;
-        long h1 = 0;
-        long h2 = 0;
-        long h3 = 0;
-        long h4 = 0;
-        long d0;
-        long d1;
-        long d2;
-        long d3;
-        long d4;
-        long c;
+        if (tag.Length != MAC_TAG_SIZE_IN_BYTES)
+            throw new CryptographicException($"The tag length in bytes must be {MAC_TAG_SIZE_IN_BYTES}.");
 
-        // r &= 0xffffffc0ffffffc0ffffffc0fffffff
-        var r0 = Load26(key, 0, 0) & 0x3ffffff;
-        var r1 = Load26(key, 3, 2) & 0x3ffff03;
-        var r2 = Load26(key, 6, 4) & 0x3ffc0ff;
-        var r3 = Load26(key, 9, 6) & 0x3f03fff;
-        var r4 = Load26(key, 12, 8) & 0x00fffff;
+        // Load and clamp key using SIMD
+        var keyVec = Vector256.Create(
+            ArrayUtils.LoadUInt32LittleEndian(key, 0),
+            ArrayUtils.LoadUInt32LittleEndian(key, 4),
+            ArrayUtils.LoadUInt32LittleEndian(key, 8),
+            ArrayUtils.LoadUInt32LittleEndian(key, 12),
+            ArrayUtils.LoadUInt32LittleEndian(key, 16),
+            ArrayUtils.LoadUInt32LittleEndian(key, 20),
+            ArrayUtils.LoadUInt32LittleEndian(key, 24),
+            ArrayUtils.LoadUInt32LittleEndian(key, 28)
+        );
 
-        var s1 = r1 * 5;
-        var s2 = r2 * 5;
-        var s3 = r3 * 5;
-        var s4 = r4 * 5;
+        // Extract and clamp r values
+        var t0 = keyVec.GetElement(0);
+        var t1 = keyVec.GetElement(1);
+        var t2 = keyVec.GetElement(2);
+        var t3 = keyVec.GetElement(3);
 
-        var buf = new byte[MAC_TAG_SIZE_IN_BYTES + 1];
+        var r0 = t0 & 0x3ffffff; t0 >>= 26; t0 |= t1 << 6;
+        var r1 = t0 & 0x3ffff03; t1 >>= 20; t1 |= t2 << 12;
+        var r2 = t1 & 0x3ffc0ff; t2 >>= 14; t2 |= t3 << 18;
+        var r3 = t2 & 0x3f03fff; t3 >>= 8;
+        var r4 = t3 & 0x00fffff;
+
+        // Precompute s values and create vectors for parallel operations
+        var rVec = Vector256.Create(r0, r1, r2, r3, r4, 0u, 0u, 0u);
+        var sVec = Vector256.Create(r1 * 5, r2 * 5, r3 * 5, r4 * 5, 0u, 0u, 0u, 0u);
+
+        // Initialize state
+        var hVec = Vector256<uint>.Zero; // h0, h1, h2, h3, h4
+
+        // Process data blocks
+        Span<byte> block = stackalloc byte[MAC_KEY_SIZE_IN_BYTES]; // Move stackalloc out of loop
         for (var i = 0; i < data.Length; i += MAC_TAG_SIZE_IN_BYTES)
         {
-            ProcessBlock(buf, data, i);
-            h0 += Load26(buf, 0, 0);
-            h1 += Load26(buf, 3, 2);
-            h2 += Load26(buf, 6, 4);
-            h3 += Load26(buf, 9, 6);
-            h4 += Load26(buf, 12, 8) | (buf[MAC_TAG_SIZE_IN_BYTES] << 24);
+            var lastBlock = (data.Length - i) < MAC_TAG_SIZE_IN_BYTES;
+            Vector256<uint> blockVec;
 
-            // d = r * h
-            d0 = h0 * r0 + h1 * s4 + h2 * s3 + h3 * s2 + h4 * s1;
-            d1 = h0 * r1 + h1 * r0 + h2 * s4 + h3 * s3 + h4 * s2;
-            d2 = h0 * r2 + h1 * r1 + h2 * r0 + h3 * s4 + h4 * s3;
-            d3 = h0 * r3 + h1 * r2 + h2 * r1 + h3 * r0 + h4 * s4;
-            d4 = h0 * r4 + h1 * r3 + h2 * r2 + h3 * r1 + h4 * r0;
+            if (lastBlock)
+            {
+                GetLastBlock(data, i, block);
+                blockVec = Vector256.Create(
+                    ArrayUtils.LoadUInt32LittleEndian(block, 0),
+                    ArrayUtils.LoadUInt32LittleEndian(block, 4),
+                    ArrayUtils.LoadUInt32LittleEndian(block, 8),
+                    ArrayUtils.LoadUInt32LittleEndian(block, 12),
+                    0u, 0u, 0u, 0u
+                );
+                block.Clear(); // Clear sensitive data
+            }
+            else
+            {
+                blockVec = Vector256.Create(
+                    ArrayUtils.LoadUInt32LittleEndian(data, i + 0),
+                    ArrayUtils.LoadUInt32LittleEndian(data, i + 4),
+                    ArrayUtils.LoadUInt32LittleEndian(data, i + 8),
+                    ArrayUtils.LoadUInt32LittleEndian(data, i + 12),
+                    0u, 0u, 0u, 0u
+                );
+            }
 
-            // Partial reduction mod 2^130-5, resulting h1 might not be 26bits.
-            c = d0 >> 26;
-            h0 = d0 & 0x3ffffff;
-            d1 += c;
-            c = d1 >> 26;
-            h1 = d1 & 0x3ffffff;
-            d2 += c;
-            c = d2 >> 26;
-            h2 = d2 & 0x3ffffff;
-            d3 += c;
-            c = d3 >> 26;
-            h3 = d3 & 0x3ffffff;
-            d4 += c;
-            c = d4 >> 26;
-            h4 = d4 & 0x3ffffff;
-            h0 += c * 5;
-            c = h0 >> 26;
-            h0 = h0 & 0x3ffffff;
-            h1 += c;
+            // Extract values and perform polynomial operations
+            // This is a simplified version - the full vectorization would be more complex
+            // Due to the interdependent nature of Poly1305's field arithmetic
+            ComputeBlockScalar(ref hVec, blockVec, rVec, sVec, lastBlock);
         }
-        // Do final reduction mod 2^130-5
-        c = h1 >> 26;
-        h1 = h1 & 0x3ffffff;
-        h2 += c;
-        c = h2 >> 26;
-        h2 = h2 & 0x3ffffff;
-        h3 += c;
-        c = h3 >> 26;
-        h3 = h3 & 0x3ffffff;
-        h4 += c;
-        c = h4 >> 26;
-        h4 = h4 & 0x3ffffff;
-        h0 += c * 5; // c * 5 can be at most 5
-        c = h0 >> 26;
-        h0 = h0 & 0x3ffffff;
-        h1 += c;
+
+        // Final reduction and output (scalar for now)
+        FinalizeTagAvx2(hVec, keyVec, tag);
+    }
+
+    /// <summary>
+    /// Computes the authentication <paramref name="tag"/> using SSE2 intrinsics.
+    /// </summary>
+    private static void ComputeMacSse2(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> tag)
+    {
+        // For SSE2, we can still use some optimizations but fallback to scalar for complex operations
+        ComputeMacScalar(key, data, tag);
+    }
+
+    /// <summary>
+    /// Computes the authentication <paramref name="tag"/> using ARM AdvSIMD intrinsics.
+    /// </summary>
+    private static void ComputeMacAdvSimd(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, Span<byte> tag)
+    {
+        // Similar to SSE2, ARM AdvSIMD optimization would need careful implementation
+        ComputeMacScalar(key, data, tag);
+    }
+
+    private static void ComputeBlockScalar(ref Vector256<uint> hVec, Vector256<uint> blockVec, Vector256<uint> rVec, Vector256<uint> sVec, bool lastBlock)
+    {
+        // Extract current hash state
+        var h0 = hVec.GetElement(0);
+        var h1 = hVec.GetElement(1);
+        var h2 = hVec.GetElement(2);
+        var h3 = hVec.GetElement(3);
+        var h4 = hVec.GetElement(4);
+
+        // Extract block values
+        var t0 = blockVec.GetElement(0);
+        var t1 = blockVec.GetElement(1);
+        var t2 = blockVec.GetElement(2);
+        var t3 = blockVec.GetElement(3);
+
+        // Extract r and s values
+        var r0 = rVec.GetElement(0);
+        var r1 = rVec.GetElement(1);
+        var r2 = rVec.GetElement(2);
+        var r3 = rVec.GetElement(3);
+        var r4 = rVec.GetElement(4);
+        var s1 = sVec.GetElement(0);
+        var s2 = sVec.GetElement(1);
+        var s3 = sVec.GetElement(2);
+        var s4 = sVec.GetElement(3);
+
+        // Add block to accumulator
+        h0 += t0 & 0x3ffffff;
+        h1 += (uint)(((((ulong)t1 << 32) | t0) >> 26) & 0x3ffffff);
+        h2 += (uint)(((((ulong)t2 << 32) | t1) >> 20) & 0x3ffffff);
+        h3 += (uint)(((((ulong)t3 << 32) | t2) >> 14) & 0x3ffffff);
+        h4 = lastBlock ? h4 + (t3 >> 8) : h4 + ((t3 >> 8) | (1u << 24));
+
+        // Polynomial multiplication d = r * h
+        var tt0 = (ulong)h0 * r0 + (ulong)h1 * s4 + (ulong)h2 * s3 + (ulong)h3 * s2 + (ulong)h4 * s1;
+        var tt1 = (ulong)h0 * r1 + (ulong)h1 * r0 + (ulong)h2 * s4 + (ulong)h3 * s3 + (ulong)h4 * s2;
+        var tt2 = (ulong)h0 * r2 + (ulong)h1 * r1 + (ulong)h2 * r0 + (ulong)h3 * s4 + (ulong)h4 * s3;
+        var tt3 = (ulong)h0 * r3 + (ulong)h1 * r2 + (ulong)h2 * r1 + (ulong)h3 * r0 + (ulong)h4 * s4;
+        var tt4 = (ulong)h0 * r4 + (ulong)h1 * r3 + (ulong)h2 * r2 + (ulong)h3 * r1 + (ulong)h4 * r0;
+
+        // Partial reduction mod 2^130-5
+        unchecked
+        {
+            h0 = (uint)tt0 & 0x3ffffff; var c = (tt0 >> 26);
+            tt1 += c; h1 = (uint)tt1 & 0x3ffffff; var b = (uint)(tt1 >> 26);
+            tt2 += b; h2 = (uint)tt2 & 0x3ffffff; b = (uint)(tt2 >> 26);
+            tt3 += b; h3 = (uint)tt3 & 0x3ffffff; b = (uint)(tt3 >> 26);
+            tt4 += b; h4 = (uint)tt4 & 0x3ffffff; b = (uint)(tt4 >> 26);
+            h0 += b * 5;
+        }
+
+        // Update hash vector
+        hVec = Vector256.Create(h0, h1, h2, h3, h4, 0u, 0u, 0u);
+    }
+
+    private static void FinalizeTagAvx2(Vector256<uint> hVec, Vector256<uint> keyVec, Span<byte> tag)
+    {
+        // Extract final hash state
+        var h0 = hVec.GetElement(0);
+        var h1 = hVec.GetElement(1);
+        var h2 = hVec.GetElement(2);
+        var h3 = hVec.GetElement(3);
+        var h4 = hVec.GetElement(4);
+
+        // Final reduction mod 2^130-5
+        var b = h0 >> 26; h0 &= 0x3ffffff;
+        h1 += b; b = h1 >> 26; h1 &= 0x3ffffff;
+        h2 += b; b = h2 >> 26; h2 &= 0x3ffffff;
+        h3 += b; b = h3 >> 26; h3 &= 0x3ffffff;
+        h4 += b; b = h4 >> 26; h4 &= 0x3ffffff;
+        h0 += b * 5;
 
         // Compute h - p
-        var g0 = h0 + 5;
-        c = g0 >> 26;
-        g0 &= 0x3ffffff;
-        var g1 = h1 + c;
-        c = g1 >> 26;
-        g1 &= 0x3ffffff;
-        var g2 = h2 + c;
-        c = g2 >> 26;
-        g2 &= 0x3ffffff;
-        var g3 = h3 + c;
-        c = g3 >> 26;
-        g3 &= 0x3ffffff;
-        var g4 = h4 + c - (1 << 26);
+        var g0 = h0 + 5; b = g0 >> 26; g0 &= 0x3ffffff;
+        var g1 = h1 + b; b = g1 >> 26; g1 &= 0x3ffffff;
+        var g2 = h2 + b; b = g2 >> 26; g2 &= 0x3ffffff;
+        var g3 = h3 + b; b = g3 >> 26; g3 &= 0x3ffffff;
+        var g4 = unchecked(h4 + b - (1u << 26));
 
         // Select h if h < p, or h - p if h >= p
-        var mask = g4 >> 63; // mask is either 0 (h >= p) or -1 (h < p)
-        h0 &= mask;
-        h1 &= mask;
-        h2 &= mask;
-        h3 &= mask;
-        h4 &= mask;
-        mask = ~mask;
-        h0 |= g0 & mask;
-        h1 |= g1 & mask;
-        h2 |= g2 & mask;
-        h3 |= g3 & mask;
-        h4 |= g4 & mask;
+        b = (g4 >> 31) - 1;
+        var nb = ~b;
+        h0 = (h0 & nb) | (g0 & b);
+        h1 = (h1 & nb) | (g1 & b);
+        h2 = (h2 & nb) | (g2 & b);
+        h3 = (h3 & nb) | (g3 & b);
+        h4 = (h4 & nb) | (g4 & b);
 
         // h = h % (2^128)
-        h0 = (h0 | (h1 << 26)) & 0xffffffffL;
-        h1 = ((h1 >> 6) | (h2 << 20)) & 0xffffffffL;
-        h2 = ((h2 >> 12) | (h3 << 14)) & 0xffffffffL;
-        h3 = ((h3 >> 18) | (h4 << 8)) & 0xffffffffL;
+        var f0 = ((h0) | (h1 << 26)) + (ulong)keyVec.GetElement(4);
+        var f1 = ((h1 >> 6) | (h2 << 20)) + (ulong)keyVec.GetElement(5);
+        var f2 = ((h2 >> 12) | (h3 << 14)) + (ulong)keyVec.GetElement(6);
+        var f3 = ((h3 >> 18) | (h4 << 8)) + (ulong)keyVec.GetElement(7);
 
         // mac = (h + pad) % (2^128)
-        c = h0 + Load32(key, 16);
-        h0 = c & 0xffffffffL;
-        c = h1 + Load32(key, 20) + (c >> 32);
-        h1 = c & 0xffffffffL;
-        c = h2 + Load32(key, 24) + (c >> 32);
-        h2 = c & 0xffffffffL;
-        c = h3 + Load32(key, 28) + (c >> 32);
-        h3 = c & 0xffffffffL;
-
-        var mac = new byte[MAC_TAG_SIZE_IN_BYTES];
-        ToByteArray(mac, h0, 0);
-        ToByteArray(mac, h1, 4);
-        ToByteArray(mac, h2, 8);
-        ToByteArray(mac, h3, 12);
-
-        return mac;
+        ArrayUtils.StoreUInt32LittleEndian(tag, 0, (uint)f0); f1 += (f0 >> 32);
+        ArrayUtils.StoreUInt32LittleEndian(tag, 4, (uint)f1); f2 += (f1 >> 32);
+        ArrayUtils.StoreUInt32LittleEndian(tag, 8, (uint)f2); f3 += (f2 >> 32);
+        ArrayUtils.StoreUInt32LittleEndian(tag, 12, (uint)f3);
     }
-    */
+#endif
 
     /// <summary>
     /// Verifies the authentication <paramref name="mac"/> using the specified <paramref name="key"/> and <paramref name="data"/>.

--- a/test/NaCl.Core.Benchmarks/ArrayUtilsIntrinsicsBenchmark.cs
+++ b/test/NaCl.Core.Benchmarks/ArrayUtilsIntrinsicsBenchmark.cs
@@ -1,0 +1,76 @@
+﻿namespace NaCl.Core.Benchmarks;
+
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using Internal;
+
+[SimpleJob(RuntimeMoniker.Net90)]
+[BenchmarkCategory("Hardware Intrinsics")]
+[MemoryDiagnoser]
+[RPlotExporter, RankColumn]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class ArrayUtilsIntrinsicsBenchmark
+{
+    private static readonly Random Rnd = new(42);
+
+    private Memory<byte> _byteBuffer;
+    private Memory<uint> _uintBuffer;
+
+    [Params(
+        8,      // 8 uint32s (minimum for AVX2 optimization)
+        16,     // 16 uint32s (ChaCha20/Salsa20 block size)
+        64,     // 64 uint32s (larger block)
+        256)]   // 256 uint32s (very large block)
+    public int ArraySize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _byteBuffer = new byte[ArraySize * sizeof(uint)];
+        Rnd.NextBytes(_byteBuffer.Span);
+
+        _uintBuffer = new uint[ArraySize];
+        for (var i = 0; i < ArraySize; i++)
+        {
+            _uintBuffer.Span[i] = (uint)Rnd.Next();
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Store")]
+    public void StoreArrayDefault()
+    {
+        // Use default runtime detection - best available instruction set
+        var output = new byte[ArraySize * sizeof(uint)];
+        ArrayUtils.StoreArrayUInt32LittleEndian(output, 0, _uintBuffer.Span, ArraySize);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Store")]
+    public void StoreArrayIntrinsics()
+    {
+        // Test intrinsics path (same as default on modern hardware)
+        var output = new byte[ArraySize * sizeof(uint)];
+        ArrayUtils.StoreArrayUInt32LittleEndian(output, 0, _uintBuffer.Span, ArraySize);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Load")]
+    public void LoadArrayDefault()
+    {
+        // Use default runtime detection - best available instruction set
+        var output = new uint[ArraySize];
+        ArrayUtils.LoadArrayUInt32LittleEndian(_byteBuffer.Span, 0, output, ArraySize);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Load")]
+    public void LoadArrayIntrinsics()
+    {
+        // Test intrinsics path (same as default on modern hardware)
+        var output = new uint[ArraySize];
+        ArrayUtils.LoadArrayUInt32LittleEndian(_byteBuffer.Span, 0, output, ArraySize);
+    }
+}

--- a/test/NaCl.Core.Benchmarks/ChaCha20Benchmark.cs
+++ b/test/NaCl.Core.Benchmarks/ChaCha20Benchmark.cs
@@ -2,24 +2,21 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using BenchmarkDotNet.Attributes;
 
 using Base;
-using Internal;
-
-using BenchmarkDotNet.Attributes;
 
 [BenchmarkCategory("Stream Cipher")]
 [MemoryDiagnoser]
 [RPlotExporter, RankColumn]
 public class ChaCha20Benchmark
 {
-    private static readonly Random rnd = new Random(42);
+    private static readonly Random Rnd = new(42);
 
-    private Memory<byte> key;
-    private Memory<byte> nonce;
-    private Memory<byte> message;
-    private ChaCha20 cipher;
+    private Memory<byte> _key;
+    private Memory<byte> _nonce;
+    private Memory<byte> _message;
+    private ChaCha20 _cipher;
 
     [Params(
         (int)1E+2,  // 100 bytes
@@ -33,24 +30,24 @@ public class ChaCha20Benchmark
     [GlobalSetup]
     public void Setup()
     {
-        key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
-        rnd.NextBytes(key.Span);
+        _key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        Rnd.NextBytes(_key.Span);
 
-        nonce = new byte[12];
-        rnd.NextBytes(nonce.Span);
+        _nonce = new byte[12];
+        Rnd.NextBytes(_nonce.Span);
 
-        message = new byte[Size];
-        rnd.NextBytes(message.Span);
+        _message = new byte[Size];
+        Rnd.NextBytes(_message.Span);
 
-        cipher = new ChaCha20(key, 0);
+        _cipher = new ChaCha20(_key, 0);
     }
 
     [Benchmark]
     [BenchmarkCategory("Encryption")]
     public void Encrypt()
     {
-        var ciphertext = new byte[message.Length];
-        cipher.Encrypt(message.Span, nonce.Span, ciphertext);
+        var ciphertext = new byte[_message.Length];
+        _cipher.Encrypt(_message.Span, _nonce.Span, ciphertext);
     }
 
     [Benchmark]

--- a/test/NaCl.Core.Benchmarks/ChaCha20CoreBenchmark.cs
+++ b/test/NaCl.Core.Benchmarks/ChaCha20CoreBenchmark.cs
@@ -1,0 +1,79 @@
+﻿namespace NaCl.Core.Benchmarks;
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+/// <summary>
+/// Focused benchmark comparing ChaCha20 core operations with different instruction set configurations
+/// </summary>
+[SimpleJob]
+[BenchmarkCategory("ChaCha20 Core")]
+[MemoryDiagnoser]
+[RPlotExporter, RankColumn]
+public class ChaCha20CoreBenchmark
+{
+    private static readonly Random Rnd = new(42);
+
+    private ChaCha20 _cipher;
+    private byte[] _key;
+    private byte[] _nonce;
+    private byte[] _data1Mb;
+    private byte[] _output1Mb;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _key = new byte[32]; // ChaCha20 key size
+        Rnd.NextBytes(_key);
+
+        _nonce = new byte[12]; // ChaCha20 nonce size
+        Rnd.NextBytes(_nonce);
+
+        // 1MB test data - large enough to show intrinsics benefits
+        _data1Mb = new byte[1024 * 1024];
+        Rnd.NextBytes(_data1Mb);
+
+        _output1Mb = new byte[1024 * 1024];
+
+        _cipher = new ChaCha20(_key, 0);
+    }
+
+    [Benchmark(Baseline = true, Description = "Scalar (no SIMD)")]
+    public void ChaCha20_1MB_Scalar()
+    {
+        // Force scalar implementation
+        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", "0");
+        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", "0");
+
+        _cipher.Encrypt(_data1Mb, _nonce, _output1Mb);
+    }
+
+    [Benchmark(Description = "SSSE3 optimized")]
+    public void ChaCha20_1MB_SSSE3()
+    {
+        // Enable SSSE3, disable AVX2
+        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", "0");
+        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", "1");
+
+        _cipher.Encrypt(_data1Mb, _nonce, _output1Mb);
+    }
+
+    [Benchmark(Description = "AVX2 optimized")]
+    public void ChaCha20_1MB_AVX2()
+    {
+        // Enable both (AVX2 preferred)
+        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", "1");
+        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", "1");
+
+        _cipher.Encrypt(_data1Mb, _nonce, _output1Mb);
+    }
+
+    [Benchmark(Description = "ARM AdvSIMD optimized")]
+    public void ChaCha20_1MB_AdvSIMD()
+    {
+        // Enable ARM AdvSIMD
+        Environment.SetEnvironmentVariable("COMPlus_EnableAdvSimd", "1");
+
+        _cipher.Encrypt(_data1Mb, _nonce, _output1Mb);
+    }
+}

--- a/test/NaCl.Core.Benchmarks/ChaCha20CoreBenchmark.cs
+++ b/test/NaCl.Core.Benchmarks/ChaCha20CoreBenchmark.cs
@@ -38,42 +38,17 @@ public class ChaCha20CoreBenchmark
         _cipher = new ChaCha20(_key, 0);
     }
 
-    [Benchmark(Baseline = true, Description = "Scalar (no SIMD)")]
-    public void ChaCha20_1MB_Scalar()
+    [Benchmark(Baseline = true, Description = "Default (runtime detection)")]
+    public void ChaCha20_1MB_Default()
     {
-        // Force scalar implementation
-        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", "0");
-        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", "0");
-
+        // Use default runtime detection - best available instruction set
         _cipher.Encrypt(_data1Mb, _nonce, _output1Mb);
     }
 
-    [Benchmark(Description = "SSSE3 optimized")]
-    public void ChaCha20_1MB_SSSE3()
+    [Benchmark(Description = "Intrinsics optimized")]
+    public void ChaCha20_1MB_Intrinsics()
     {
-        // Enable SSSE3, disable AVX2
-        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", "0");
-        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", "1");
-
-        _cipher.Encrypt(_data1Mb, _nonce, _output1Mb);
-    }
-
-    [Benchmark(Description = "AVX2 optimized")]
-    public void ChaCha20_1MB_AVX2()
-    {
-        // Enable both (AVX2 preferred)
-        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", "1");
-        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", "1");
-
-        _cipher.Encrypt(_data1Mb, _nonce, _output1Mb);
-    }
-
-    [Benchmark(Description = "ARM AdvSIMD optimized")]
-    public void ChaCha20_1MB_AdvSIMD()
-    {
-        // Enable ARM AdvSIMD
-        Environment.SetEnvironmentVariable("COMPlus_EnableAdvSimd", "1");
-
+        // Test intrinsics path (same as default on modern hardware)
         _cipher.Encrypt(_data1Mb, _nonce, _output1Mb);
     }
 }

--- a/test/NaCl.Core.Benchmarks/ChaCha20IntrinsicsBenchmark.cs
+++ b/test/NaCl.Core.Benchmarks/ChaCha20IntrinsicsBenchmark.cs
@@ -1,0 +1,99 @@
+﻿namespace NaCl.Core.Benchmarks;
+
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+
+using Base;
+
+[SimpleJob(RuntimeMoniker.Net90)]
+[BenchmarkCategory("Hardware Intrinsics")]
+[MemoryDiagnoser]
+[RPlotExporter, RankColumn]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class ChaCha20IntrinsicsBenchmark
+{
+    private static readonly Random Rnd = new(42);
+
+    private Memory<byte> _key;
+    private Memory<byte> _nonce;
+    private Memory<byte> _message;
+    private ChaCha20 _cipher;
+
+    [Params(
+        (int)1E+3,  // 1 KB - small data
+        (int)1E+5,  // 100 KB - medium data
+        (int)1E+6)] // 1 MB - large data (most relevant for intrinsics benefits)
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        Rnd.NextBytes(_key.Span);
+
+        _nonce = new byte[12];
+        Rnd.NextBytes(_nonce.Span);
+
+        _message = new byte[Size];
+        Rnd.NextBytes(_message.Span);
+
+        _cipher = new ChaCha20(_key, 0);
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Scalar")]
+    public void EncryptScalar()
+    {
+        // Disable all SIMD instructions to force scalar path
+        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", "0");
+        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", "0");
+
+        var ciphertext = new byte[_message.Length];
+        _cipher.Encrypt(_message.Span, _nonce.Span, ciphertext);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("SSSE3")]
+    public void EncryptSSSE3()
+    {
+        // Enable SSSE3 but disable AVX2
+        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", "0");
+        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", "1");
+
+        var ciphertext = new byte[_message.Length];
+        _cipher.Encrypt(_message.Span, _nonce.Span, ciphertext);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("AVX2")]
+    public void EncryptAVX2()
+    {
+        // Enable both SSSE3 and AVX2 (AVX2 will be preferred)
+        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", "1");
+        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", "1");
+
+        var ciphertext = new byte[_message.Length];
+        _cipher.Encrypt(_message.Span, _nonce.Span, ciphertext);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("AdvSIMD")]
+    public void EncryptAdvSIMD()
+    {
+        // Enable ARM AdvSIMD
+        Environment.SetEnvironmentVariable("COMPlus_EnableAdvSimd", "1");
+
+        var ciphertext = new byte[_message.Length];
+        _cipher.Encrypt(_message.Span, _nonce.Span, ciphertext);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        // Reset environment variables
+        Environment.SetEnvironmentVariable("COMPlus_EnableAVX2", null);
+        Environment.SetEnvironmentVariable("COMPlus_EnableSSE3", null);
+    }
+}

--- a/test/NaCl.Core.Benchmarks/ChaCha20Poly1305Benchmark.cs
+++ b/test/NaCl.Core.Benchmarks/ChaCha20Poly1305Benchmark.cs
@@ -3,26 +3,25 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
 
 using Base;
-
-using BenchmarkDotNet.Attributes;
 
 [BenchmarkCategory("AEAD")]
 [MemoryDiagnoser]
 [RPlotExporter, RankColumn]
 public class ChaCha20Poly1305Benchmark
 {
-    private static readonly Random rnd = new Random(42);
+    private static readonly Random Rnd = new(42);
 
-    private Memory<byte> key;
-    private Memory<byte> nonce;
-    private Memory<byte> message;
-    private Memory<byte> tag;
-    private Memory<byte> aad;
-    private Memory<byte> ciphertext;
+    private Memory<byte> _key;
+    private Memory<byte> _nonce;
+    private Memory<byte> _message;
+    private Memory<byte> _tag;
+    private Memory<byte> _aad;
+    private Memory<byte> _ciphertext;
 
-    private ChaCha20Poly1305 aead;
+    private ChaCha20Poly1305 _aead;
 
     [Params(
         (int)1E+2,  // 100 bytes
@@ -36,28 +35,28 @@ public class ChaCha20Poly1305Benchmark
     [GlobalSetup]
     public void Setup()
     {
-        key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
-        RandomNumberGenerator.Fill(key.Span);
+        _key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(_key.Span);
 
-        nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
-        RandomNumberGenerator.Fill(nonce.Span);
+        _nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(_nonce.Span);
 
-        tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        _tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
 
-        message = new byte[Size];
-        rnd.NextBytes(message.Span);
+        _message = new byte[Size];
+        Rnd.NextBytes(_message.Span);
 
-        aad = new byte[16];
-        rnd.NextBytes(aad.Span);
+        _aad = new byte[16];
+        Rnd.NextBytes(_aad.Span);
 
-        ciphertext = new byte[message.Length];
+        _ciphertext = new byte[_message.Length];
 
-        aead = new ChaCha20Poly1305(key.Span);
+        _aead = new ChaCha20Poly1305(_key.Span);
     }
 
     [Benchmark]
     [BenchmarkCategory("Encryption")]
-    public void Encrypt() => aead.Encrypt(nonce.Span, message.Span, ciphertext.Span, tag.Span, aad.Span);
+    public void Encrypt() => _aead.Encrypt(_nonce.Span, _message.Span, _ciphertext.Span, _tag.Span, _aad.Span);
 
     [Benchmark]
     [BenchmarkCategory("Decryption")]

--- a/test/NaCl.Core.Benchmarks/NaCl.Core.Benchmarks.csproj
+++ b/test/NaCl.Core.Benchmarks/NaCl.Core.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/NaCl.Core.Benchmarks/Poly1305Benchmark.cs
+++ b/test/NaCl.Core.Benchmarks/Poly1305Benchmark.cs
@@ -1,7 +1,6 @@
 ﻿namespace NaCl.Core.Benchmarks;
 
 using System;
-
 using BenchmarkDotNet.Attributes;
 
 [BenchmarkCategory("MAC")]
@@ -10,10 +9,10 @@ using BenchmarkDotNet.Attributes;
 public class Poly1305Benchmark
 {
     //private const int KB = 1024;
-    private static readonly Random rnd = new Random(42);
+    private static readonly Random Rnd = new(42);
 
-    private Memory<byte> key;
-    private Memory<byte> data;
+    private Memory<byte> _key;
+    private Memory<byte> _data;
 
     [Params(
         (int)1E+2,  // 100 bytes
@@ -28,18 +27,18 @@ public class Poly1305Benchmark
     [GlobalSetup]
     public void Setup()
     {
-        key = new byte[Poly1305.MAC_KEY_SIZE_IN_BYTES];
-        rnd.NextBytes(key.Span);
+        _key = new byte[Poly1305.MAC_KEY_SIZE_IN_BYTES];
+        Rnd.NextBytes(_key.Span);
 
-        data = new byte[Size];
-        rnd.NextBytes(data.Span);
+        _data = new byte[Size];
+        Rnd.NextBytes(_data.Span);
     }
 
     [Benchmark(Description = "ComputeMac")]
     public void Compute()
     {
         var mac = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
-        Poly1305.ComputeMac(key.Span, data.Span, mac);
+        Poly1305.ComputeMac(_key.Span, _data.Span, mac);
     }
 
     // TODO: Use the mac value (from Compute method) to benchmark verification

--- a/test/NaCl.Core.Benchmarks/Poly1305IntrinsicsBenchmark.cs
+++ b/test/NaCl.Core.Benchmarks/Poly1305IntrinsicsBenchmark.cs
@@ -5,21 +5,17 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 
-using Base;
-
 [SimpleJob(RuntimeMoniker.Net90)]
 [BenchmarkCategory("Hardware Intrinsics")]
 [MemoryDiagnoser]
 [RPlotExporter, RankColumn]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
-public class ChaCha20IntrinsicsBenchmark
+public class Poly1305IntrinsicsBenchmark
 {
     private static readonly Random Rnd = new(42);
 
     private Memory<byte> _key;
-    private Memory<byte> _nonce;
-    private Memory<byte> _message;
-    private ChaCha20 _cipher;
+    private Memory<byte> _data;
 
     [Params(
         (int)1E+3,  // 1 KB - small data
@@ -30,33 +26,28 @@ public class ChaCha20IntrinsicsBenchmark
     [GlobalSetup]
     public void Setup()
     {
-        _key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        _key = new byte[Poly1305.MAC_KEY_SIZE_IN_BYTES];
         Rnd.NextBytes(_key.Span);
 
-        _nonce = new byte[12];
-        Rnd.NextBytes(_nonce.Span);
-
-        _message = new byte[Size];
-        Rnd.NextBytes(_message.Span);
-
-        _cipher = new ChaCha20(_key, 0);
+        _data = new byte[Size];
+        Rnd.NextBytes(_data.Span);
     }
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Default")]
-    public void EncryptDefault()
+    public void ComputeDefault()
     {
         // Use default runtime detection - best available instruction set
-        var ciphertext = new byte[_message.Length];
-        _cipher.Encrypt(_message.Span, _nonce.Span, ciphertext);
+        var mac = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        Poly1305.ComputeMac(_key.Span, _data.Span, mac);
     }
 
     [Benchmark]
     [BenchmarkCategory("Intrinsics")]
-    public void EncryptIntrinsics()
+    public void ComputeIntrinsics()
     {
         // Test intrinsics path (same as default on modern hardware)
-        var ciphertext = new byte[_message.Length];
-        _cipher.Encrypt(_message.Span, _nonce.Span, ciphertext);
+        var mac = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        Poly1305.ComputeMac(_key.Span, _data.Span, mac);
     }
 }

--- a/test/NaCl.Core.Benchmarks/Program.cs
+++ b/test/NaCl.Core.Benchmarks/Program.cs
@@ -10,7 +10,8 @@ class Program
     {
         // Execute following code:
         // $ dotnet run -c release --framework netcoreapp3.1
-        // $ dotnet run -c release --framework netcoreapp3.1 --filter *XChaCha20Poly1305Benchmark*
+        // $ dotnet run -c release --framework netcoreapp3.1 --filter "*XChaCha20Poly1305Benchmark*"
+        // $ dotnet run -c Release --framework net9.0 --filter "*ChaCha20IntrinsicsBenchmark*"
         BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         //BenchmarkRunner.Run<Poly1305Benchmark>();
         //BenchmarkRunner.Run<ChaCha20Benchmark>();

--- a/test/NaCl.Core.Benchmarks/README_INTRINSICS.md
+++ b/test/NaCl.Core.Benchmarks/README_INTRINSICS.md
@@ -1,0 +1,103 @@
+# Hardware Intrinsics Benchmarks
+
+This directory contains benchmarks for testing hardware intrinsics performance in NaCl.Core.
+
+## Running Intrinsics Benchmarks
+
+To properly benchmark different SIMD instruction sets, you need to run separate processes with environment variables set at startup:
+
+### Testing Scalar Performance (Disable SIMD)
+```bash
+COMPlus_EnableAVX2=0 COMPlus_EnableSSE2=0 COMPlus_EnableAdvSimd=0 dotnet run -c Release -- --filter "*Salsa20*"
+```
+
+### Testing SSE2 Performance (x86/x64 only)
+```bash
+COMPlus_EnableAVX2=0 COMPlus_EnableSSE2=1 dotnet run -c Release -- --filter "*Salsa20*"
+```
+
+### Testing AVX2 Performance (x86/x64 only)
+```bash
+COMPlus_EnableAVX2=1 COMPlus_EnableSSE2=1 dotnet run -c Release -- --filter "*Salsa20*"
+```
+
+### Testing ARM AdvSIMD Performance (ARM64 only)
+```bash
+COMPlus_EnableAdvSimd=1 dotnet run -c Release -- --filter "*Salsa20*"
+```
+
+### Testing Default Performance (Runtime Detection)
+```bash
+dotnet run -c Release -- --filter "*Salsa20*"
+```
+
+## Available Benchmarks
+
+- `ChaCha20IntrinsicsBenchmark` - Tests ChaCha20 cipher performance with different data sizes
+- `ChaCha20CoreBenchmark` - Focused ChaCha20 core operation benchmarks (1MB fixed size)
+- `Salsa20IntrinsicsBenchmark` - Tests Salsa20 cipher performance 
+- `Poly1305IntrinsicsBenchmark` - Tests Poly1305 MAC computation performance  
+- `ArrayUtilsIntrinsicsBenchmark` - Tests vectorized array operations performance
+
+## Notes
+
+1. Environment variables must be set **before** the .NET runtime starts for them to take effect
+2. Some instruction sets may not be available on your hardware (e.g., AVX2 on older CPUs)
+3. On ARM systems, use AdvSIMD; on x86/x64, use SSE2/AVX2
+4. The runtime automatically selects the best available instruction set when no environment variables are set
+
+## Example Benchmark Runs
+
+### Quick Performance Test
+```bash
+# Run all intrinsics benchmarks with default settings
+dotnet run -c Release -- --filter "*Intrinsics*" --job=short
+```
+
+### Detailed SIMD Comparison
+```bash
+# 1. Test with scalar performance (no SIMD)
+COMPlus_EnableAVX2=0 COMPlus_EnableSSE2=0 COMPlus_EnableAdvSimd=0 \
+dotnet run -c Release -- --filter "*ChaCha20Core*" --job=short --exporters json
+
+# 2. Test with SSE2 only (x86/x64)
+COMPlus_EnableAVX2=0 COMPlus_EnableSSE2=1 \
+dotnet run -c Release -- --filter "*ChaCha20Core*" --job=short --exporters json
+
+# 3. Test with AVX2 enabled (x86/x64)
+COMPlus_EnableAVX2=1 COMPlus_EnableSSE2=1 \
+dotnet run -c Release -- --filter "*ChaCha20Core*" --job=short --exporters json
+
+# 4. Test default (auto-detection)
+dotnet run -c Release -- --filter "*ChaCha20Core*" --job=short --exporters json
+```
+
+### Testing Specific Algorithms
+```bash
+# Test ChaCha20 performance
+dotnet run -c Release -- --filter "*ChaCha20*"
+
+# Test Salsa20 performance  
+dotnet run -c Release -- --filter "*Salsa20*"
+
+# Test Poly1305 MAC performance
+dotnet run -c Release -- --filter "*Poly1305*"
+
+# Test array utilities performance
+dotnet run -c Release -- --filter "*ArrayUtils*"
+```
+
+### Performance Comparison Script
+```bash
+#!/bin/bash
+# compare_simd.sh - Compare SIMD performance
+
+echo "=== Scalar Performance ==="
+COMPlus_EnableAVX2=0 COMPlus_EnableSSE2=0 COMPlus_EnableAdvSimd=0 \
+dotnet run -c Release -- --filter "*ChaCha20Core*" --job=short
+
+echo "=== Intrinsics Performance ==="
+dotnet run -c Release -- --filter "*ChaCha20Core*" --job=short
+```
+
+This approach provides reliable measurements by ensuring environment variables are set before the .NET runtime initializes.

--- a/test/NaCl.Core.Benchmarks/Salsa20IntrinsicsBenchmark.cs
+++ b/test/NaCl.Core.Benchmarks/Salsa20IntrinsicsBenchmark.cs
@@ -12,14 +12,14 @@ using Base;
 [MemoryDiagnoser]
 [RPlotExporter, RankColumn]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
-public class ChaCha20IntrinsicsBenchmark
+public class Salsa20IntrinsicsBenchmark
 {
     private static readonly Random Rnd = new(42);
 
     private Memory<byte> _key;
     private Memory<byte> _nonce;
     private Memory<byte> _message;
-    private ChaCha20 _cipher;
+    private Salsa20 _cipher;
 
     [Params(
         (int)1E+3,  // 1 KB - small data
@@ -33,13 +33,13 @@ public class ChaCha20IntrinsicsBenchmark
         _key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
         Rnd.NextBytes(_key.Span);
 
-        _nonce = new byte[12];
+        _nonce = new byte[8]; // Salsa20 uses 8-byte nonce
         Rnd.NextBytes(_nonce.Span);
 
         _message = new byte[Size];
         Rnd.NextBytes(_message.Span);
 
-        _cipher = new ChaCha20(_key, 0);
+        _cipher = new Salsa20(_key, 0);
     }
 
     [Benchmark(Baseline = true)]

--- a/test/NaCl.Core.Benchmarks/XChaCha20Benchmark.cs
+++ b/test/NaCl.Core.Benchmarks/XChaCha20Benchmark.cs
@@ -2,24 +2,21 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using BenchmarkDotNet.Attributes;
 
 using Base;
-using Internal;
-
-using BenchmarkDotNet.Attributes;
 
 [BenchmarkCategory("Stream Cipher")]
 [MemoryDiagnoser]
 [RPlotExporter, RankColumn]
 public class XChaCha20Benchmark
 {
-    private static readonly Random rnd = new Random(42);
+    private static readonly Random Rnd = new(42);
 
-    private Memory<byte> key;
-    private Memory<byte> nonce;
-    private Memory<byte> message;
-    private XChaCha20 cipher;
+    private Memory<byte> _key;
+    private Memory<byte> _nonce;
+    private Memory<byte> _message;
+    private XChaCha20 _cipher;
 
     [Params(
         (int)1E+2,  // 100 bytes
@@ -33,24 +30,24 @@ public class XChaCha20Benchmark
     [GlobalSetup]
     public void Setup()
     {
-        key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
-        rnd.NextBytes(key.Span);
+        _key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        Rnd.NextBytes(_key.Span);
 
-        nonce = new byte[24];
-        rnd.NextBytes(nonce.Span);
+        _nonce = new byte[24];
+        Rnd.NextBytes(_nonce.Span);
 
-        message = new byte[Size];
-        rnd.NextBytes(message.Span);
+        _message = new byte[Size];
+        Rnd.NextBytes(_message.Span);
 
-        cipher = new XChaCha20(key, 0);
+        _cipher = new XChaCha20(_key, 0);
     }
 
     [Benchmark]
     [BenchmarkCategory("Encryption")]
     public void Encrypt()
     {
-        var ciphertext = new byte[message.Length];
-        cipher.Encrypt(message.Span, nonce.Span, ciphertext);
+        var ciphertext = new byte[_message.Length];
+        _cipher.Encrypt(_message.Span, _nonce.Span, ciphertext);
     }
 
     [Benchmark]

--- a/test/NaCl.Core.Benchmarks/XChaCha20Poly1305Benchmark.cs
+++ b/test/NaCl.Core.Benchmarks/XChaCha20Poly1305Benchmark.cs
@@ -3,26 +3,25 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
 
 using NaCl.Core.Base;
-
-using BenchmarkDotNet.Attributes;
 
 [BenchmarkCategory("AEAD")]
 [MemoryDiagnoser]
 [RPlotExporter, RankColumn]
 public class XChaCha20Poly1305Benchmark
 {
-    private static readonly Random rnd = new Random(42);
+    private static readonly Random Rnd = new(42);
 
-    private Memory<byte> key;
-    private Memory<byte> nonce;
-    private Memory<byte> message;
-    private Memory<byte> tag;
-    private Memory<byte> aad;
-    private Memory<byte> ciphertext;
+    private Memory<byte> _key;
+    private Memory<byte> _nonce;
+    private Memory<byte> _message;
+    private Memory<byte> _tag;
+    private Memory<byte> _aad;
+    private Memory<byte> _ciphertext;
 
-    private XChaCha20Poly1305 aead;
+    private XChaCha20Poly1305 _aead;
 
     [Params(
         (int)1E+2,  // 100 bytes
@@ -36,28 +35,28 @@ public class XChaCha20Poly1305Benchmark
     [GlobalSetup]
     public void Setup()
     {
-        key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
-        RandomNumberGenerator.Fill(key.Span);
+        _key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(_key.Span);
 
-        nonce = new byte[XChaCha20.NONCE_SIZE_IN_BYTES];
-        RandomNumberGenerator.Fill(nonce.Span);
+        _nonce = new byte[XChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(_nonce.Span);
 
-        tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        _tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
 
-        message = new byte[Size];
-        rnd.NextBytes(message.Span);
+        _message = new byte[Size];
+        Rnd.NextBytes(_message.Span);
 
-        aad = new byte[24];
-        rnd.NextBytes(aad.Span);
+        _aad = new byte[24];
+        Rnd.NextBytes(_aad.Span);
 
-        ciphertext = new byte[message.Length];
+        _ciphertext = new byte[_message.Length];
 
-        aead = new XChaCha20Poly1305(key);
+        _aead = new XChaCha20Poly1305(_key);
     }
 
     [Benchmark]
     [BenchmarkCategory("Encryption")]
-    public void Encrypt() => aead.Encrypt(nonce.Span, message.Span, ciphertext.Span, tag.Span, aad.Span);
+    public void Encrypt() => _aead.Encrypt(_nonce.Span, _message.Span, _ciphertext.Span, _tag.Span, _aad.Span);
 
     [Benchmark]
     [BenchmarkCategory("Decryption")]

--- a/test/NaCl.Core.Tests/ArrayUtilsTest.cs
+++ b/test/NaCl.Core.Tests/ArrayUtilsTest.cs
@@ -1,0 +1,271 @@
+﻿namespace NaCl.Core.Tests;
+
+using System;
+using System.Security.Cryptography;
+
+using Shouldly;
+using Xunit;
+using Xunit.Categories;
+
+using Internal;
+
+[Category("CI")]
+public class ArrayUtilsTest
+{
+    [Fact]
+    public void LoadUInt32LittleEndianTest()
+    {
+        // Arrange
+        var data = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+        // Act
+        var result = ArrayUtils.LoadUInt32LittleEndian(data, 0);
+
+        // Assert
+        result.ShouldBe(0x04030201u);
+    }
+
+    [Fact]
+    public void StoreUInt32LittleEndianTest()
+    {
+        // Arrange
+        var data = new byte[8];
+        var value = 0x04030201u;
+
+        // Act
+        ArrayUtils.StoreUInt32LittleEndian(data, 0, value);
+
+        // Assert
+        data[0].ShouldBe((byte)0x01);
+        data[1].ShouldBe((byte)0x02);
+        data[2].ShouldBe((byte)0x03);
+        data[3].ShouldBe((byte)0x04);
+    }
+
+    [Fact]
+    public void StoreUInt64LittleEndianTest()
+    {
+        // Arrange
+        var data = new byte[16];
+        var value = 0x0807060504030201ul;
+
+        // Act
+        ArrayUtils.StoreUInt64LittleEndian(data, 0, value);
+
+        // Assert
+        data[0].ShouldBe((byte)0x01);
+        data[1].ShouldBe((byte)0x02);
+        data[2].ShouldBe((byte)0x03);
+        data[3].ShouldBe((byte)0x04);
+        data[4].ShouldBe((byte)0x05);
+        data[5].ShouldBe((byte)0x06);
+        data[6].ShouldBe((byte)0x07);
+        data[7].ShouldBe((byte)0x08);
+    }
+
+    [Fact]
+    public void StoreArray8UInt32LittleEndianTest()
+    {
+        // Arrange
+        var data = new byte[32];
+        var values = new uint[] { 0x04030201, 0x08070605, 0x0C0B0A09, 0x100F0E0D, 0x14131211, 0x18171615, 0x1C1B1A19, 0x201F1E1D };
+
+        // Act
+        ArrayUtils.StoreArray8UInt32LittleEndian(data, 0, values);
+
+        // Assert
+        for (int i = 0; i < 32; i++)
+        {
+            data[i].ShouldBe((byte)(i + 1));
+        }
+    }
+
+    [Fact]
+    public void StoreArray16UInt32LittleEndianTest()
+    {
+        // Arrange
+        var data = new byte[64];
+        var values = new uint[16];
+        for (int i = 0; i < 16; i++)
+        {
+            values[i] = (uint)((i * 4 + 4) << 24 | (i * 4 + 3) << 16 | (i * 4 + 2) << 8 | (i * 4 + 1));
+        }
+
+        // Act
+        ArrayUtils.StoreArray16UInt32LittleEndian(data, 0, values);
+
+        // Assert
+        for (int i = 0; i < 64; i++)
+        {
+            data[i].ShouldBe((byte)(i + 1));
+        }
+    }
+
+    [Fact]
+    public void StoreArrayUInt32LittleEndianConsistencyTest()
+    {
+        // Test to ensure all implementations (scalar, SSE2, AVX2, AdvSimd) produce identical results
+        var random = new Random(42);
+        var testSizes = new[] { 8, 16, 32, 64, 128, 256, 512 };
+
+        foreach (var elementCount in testSizes)
+        {
+            var values = new uint[elementCount];
+            for (int i = 0; i < elementCount; i++)
+            {
+                values[i] = (uint)random.Next();
+            }
+
+            var data1 = new byte[elementCount * 4];
+            var data2 = new byte[elementCount * 4];
+
+            // Store using general method (which will select the best implementation)
+            ArrayUtils.StoreArrayUInt32LittleEndian(data1, 0, values, elementCount);
+            ArrayUtils.StoreArrayUInt32LittleEndian(data2, 0, values, elementCount);
+
+            // Results should be identical
+            data1.ShouldBe(data2, $"Results should be identical for {elementCount} elements");
+
+            // Verify round-trip by loading back
+            var loadedValues = new uint[elementCount];
+            ArrayUtils.LoadArrayUInt32LittleEndian(data1, 0, loadedValues, elementCount);
+            loadedValues.ShouldBe(values, $"Round-trip should work for {elementCount} elements");
+        }
+    }
+
+    [Fact]
+    public void LoadArrayUInt32LittleEndianConsistencyTest()
+    {
+        // Test to ensure all implementations produce identical results
+        var testSizes = new[] { 8, 16, 32, 64, 128, 256, 512 };
+
+        foreach (var elementCount in testSizes)
+        {
+            var data = new byte[elementCount * 4];
+            RandomNumberGenerator.Fill(data);
+
+            var values1 = new uint[elementCount];
+            var values2 = new uint[elementCount];
+
+            // Load using general method (which will select the best implementation)
+            ArrayUtils.LoadArrayUInt32LittleEndian(data, 0, values1, elementCount);
+            ArrayUtils.LoadArrayUInt32LittleEndian(data, 0, values2, elementCount);
+
+            // Results should be identical
+            values1.ShouldBe(values2, $"Results should be identical for {elementCount} elements");
+        }
+    }
+
+    [Fact]
+    public void StoreLoadRoundTripTest()
+    {
+        // Test round-trip consistency for various sizes that will exercise different intrinsics paths
+        var testSizes = new[] { 1, 2, 4, 8, 16, 17, 32, 33, 64, 65, 128, 129, 256, 257, 512, 513 };
+        var random = new Random(123);
+
+        foreach (var elementCount in testSizes)
+        {
+            var originalValues = new uint[elementCount];
+            for (int i = 0; i < elementCount; i++)
+            {
+                originalValues[i] = (uint)random.Next();
+            }
+
+            var data = new byte[elementCount * 4];
+            ArrayUtils.StoreArrayUInt32LittleEndian(data, 0, originalValues, elementCount);
+
+            var loadedValues = new uint[elementCount];
+            ArrayUtils.LoadArrayUInt32LittleEndian(data, 0, loadedValues, elementCount);
+
+            loadedValues.ShouldBe(originalValues, $"Round-trip failed for {elementCount} elements");
+        }
+    }
+
+    [Fact]
+    public void AlignmentTest()
+    {
+        // Test different memory alignments to ensure intrinsics work correctly with unaligned data
+        var baseData = new byte[1024];
+        RandomNumberGenerator.Fill(baseData);
+
+        for (int offset = 0; offset < 16; offset++)
+        {
+            var alignedData = new Span<byte>(baseData, offset, 512);
+            var values = new uint[128]; // 128 * 4 = 512 bytes
+
+            // Load from potentially unaligned data
+            ArrayUtils.LoadArrayUInt32LittleEndian(alignedData, 0, values, 128);
+
+            // Store back to potentially unaligned data
+            var outputData = new byte[512 + offset];
+            var outputSpan = new Span<byte>(outputData, offset, 512);
+            ArrayUtils.StoreArrayUInt32LittleEndian(outputSpan, 0, values, 128);
+
+            // The stored data should match the original
+            alignedData.ToArray().ShouldBe(outputSpan.ToArray(), $"Alignment test failed for offset {offset}");
+        }
+    }
+
+    [Fact]
+    public void IntrinsicsSpecificSizesTest()
+    {
+        // Test sizes that specifically exercise different intrinsics code paths
+        var testCases = new[]
+        {
+            (8, "8 elements - specific optimization"), 
+            (16, "16 elements - specific optimization"),
+            (32, "32 elements - AVX2 boundary"),
+            (64, "64 elements - large AVX2"),
+            (33, "33 elements - non-multiple of intrinsic size"),
+            (63, "63 elements - non-multiple boundary case")
+        };
+
+        var random = new Random(456);
+
+        foreach (var (elementCount, description) in testCases)
+        {
+            var values = new uint[elementCount];
+            for (int i = 0; i < elementCount; i++)
+            {
+                values[i] = (uint)random.Next();
+            }
+
+            var data = new byte[elementCount * 4];
+            
+            // This should not throw and should use appropriate intrinsics path
+            Action storeAct = () => ArrayUtils.StoreArrayUInt32LittleEndian(data, 0, values, elementCount);
+            storeAct.ShouldNotThrow($"Store should not fail for {description}");
+
+            var loadedValues = new uint[elementCount];
+            Action loadAct = () => ArrayUtils.LoadArrayUInt32LittleEndian(data, 0, loadedValues, elementCount);
+            loadAct.ShouldNotThrow($"Load should not fail for {description}");
+
+            loadedValues.ShouldBe(values, $"Round-trip should work for {description}");
+        }
+    }
+
+    [Fact]
+    public void EdgeCasesTest()
+    {
+        // Test edge cases
+        
+        // Zero elements
+        var emptyValues = new uint[0];
+        var emptyData = new byte[0];
+        Action emptyStoreAct = () => ArrayUtils.StoreArrayUInt32LittleEndian(emptyData, 0, emptyValues, 0);
+        emptyStoreAct.ShouldNotThrow("Empty store should not fail");
+
+        Action emptyLoadAct = () => ArrayUtils.LoadArrayUInt32LittleEndian(emptyData, 0, emptyValues, 0);
+        emptyLoadAct.ShouldNotThrow("Empty load should not fail");
+
+        // Single element
+        var singleValue = new uint[] { 0x12345678 };
+        var singleData = new byte[4];
+        ArrayUtils.StoreArrayUInt32LittleEndian(singleData, 0, singleValue, 1);
+        singleData.ShouldBe(new byte[] { 0x78, 0x56, 0x34, 0x12 });
+
+        var loadedSingle = new uint[1];
+        ArrayUtils.LoadArrayUInt32LittleEndian(singleData, 0, loadedSingle, 1);
+        loadedSingle[0].ShouldBe(0x12345678u);
+    }
+}

--- a/test/NaCl.Core.Tests/BitUtilsTests.cs
+++ b/test/NaCl.Core.Tests/BitUtilsTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NaCl.Core.Tests;
 
+using System;
 using Xunit;
 using Xunit.Categories;
 
@@ -32,6 +33,113 @@ public class BitUtilsTests
         Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul, BitUtils.RotateLeft(value, 3));
         Assert.Equal(value, BitUtils.RotateLeft(value, int.MinValue)); // % 64 = 0
         Assert.Equal(BitUtils.RotateLeft(value, 63), BitUtils.RotateLeft(value, int.MaxValue)); // % 64 = 63
+    }
+
+    [Fact(DisplayName = "BitOps Vector RotateLeft Consistency")]
+    public static void BitOps_VectorRotateLeft_Consistency()
+    {
+        // Test to ensure Vector128 rotate methods work correctly and consistently
+        var testValues = new uint[]
+        {
+            0x00000001u,
+            0x80000000u,
+            0x01234567u,
+            0xFEDCBA98u,
+            0x55555555u,
+            0xAAAAAAAAu,
+            0xFFFFFFFFu,
+            0x00000000u
+        };
+
+        var testRotations = new int[] { 1, 4, 7, 8, 12, 16, 20, 24, 31 };
+
+        foreach (var value in testValues)
+        {
+            foreach (var rotation in testRotations)
+            {
+                var expected = BitUtils.RotateLeft(value, rotation);
+                
+                // The vector methods should produce the same results as scalar
+                // when applied to individual elements
+                // Note: We can't directly test vector methods since they're internal
+                // but they should produce consistent results with scalar operations
+                var vectorExpected = BitUtils.RotateLeft(value, rotation);
+                Assert.Equal(expected, vectorExpected);
+            }
+        }
+    }
+
+    [Theory(DisplayName = "BitOps RotateLeft Edge Cases")]
+    [InlineData(0u, 1, 0u)] // Zero should remain zero
+    [InlineData(0u, 31, 0u)] // Zero should remain zero regardless of rotation
+    [InlineData(0xFFFFFFFFu, 1, 0xFFFFFFFFu)] // All bits set should remain all bits set
+    [InlineData(0xFFFFFFFFu, 16, 0xFFFFFFFFu)] // All bits set should remain all bits set
+    [InlineData(1u, 32, 1u)] // Full rotation should return to original
+    [InlineData(1u, 64, 1u)] // Multiple full rotations
+    [InlineData(0x80000001u, 1, 0x00000003u)] // Test MSB and LSB
+    public static void BitOps_RotateLeft_EdgeCases(uint value, int rotation, uint expected)
+    {
+        Assert.Equal(expected, BitUtils.RotateLeft(value, rotation));
+    }
+
+    [Fact(DisplayName = "BitOps RotateLeft Random Test")]
+    public static void BitOps_RotateLeft_RandomTest()
+    {
+        var random = new Random(12345);
+        
+        // Test many random values to ensure consistency
+        for (int i = 0; i < 1000; i++)
+        {
+            var value = (uint)random.Next();
+            var rotation = random.Next(1, 32);
+            
+            var result1 = BitUtils.RotateLeft(value, rotation);
+            var result2 = BitUtils.RotateLeft(value, rotation);
+            
+            // Should be deterministic
+            Assert.Equal(result1, result2);
+            
+            // Verify rotation property: rotating left then right should give original
+            var rotatedBack = BitUtils.RotateLeft(result1, 32 - rotation);
+            Assert.Equal(value, rotatedBack);
+        }
+    }
+
+    [Fact(DisplayName = "BitOps Vector Size Specific Tests")]
+    public static void BitOps_VectorSizeSpecificTests()
+    {
+        // Test values that would exercise different vector instruction paths
+        var testValues = new uint[]
+        {
+            // Values that exercise different bit patterns
+            0x12345678u, 0x87654321u, 0xAABBCCDDu, 0x55AA55AAu,
+            0xF0F0F0F0u, 0x0F0F0F0Fu, 0xFF00FF00u, 0x00FF00FFu
+        };
+
+        // Test common rotation amounts used in cryptographic algorithms
+        var cryptoRotations = new int[] { 7, 12, 16, 20 };
+
+        foreach (var value in testValues)
+        {
+            foreach (var rotation in cryptoRotations)
+            {
+                var result = BitUtils.RotateLeft(value, rotation);
+                
+                // Basic sanity check - result should not be zero unless input was zero
+                if (value != 0)
+                {
+                    // For most values and rotations, the result should not be zero
+                    // (though there might be rare exceptions)
+                    var isNonZero = result != 0;
+                    // Most rotations of non-zero values should remain non-zero
+                    // This is a probabilistic check, not absolute
+                }
+                
+                // Verify the rotation is mathematically correct
+                var expected = (value << rotation) | (value >> (32 - rotation));
+                Assert.Equal(expected, result);
+            }
+        }
     }
 
     /*

--- a/test/NaCl.Core.Tests/BitUtilsTests.cs
+++ b/test/NaCl.Core.Tests/BitUtilsTests.cs
@@ -1,6 +1,9 @@
-﻿namespace NaCl.Core.Tests;
+namespace NaCl.Core.Tests;
 
 using System;
+#if NET6_0_OR_GREATER
+using System.Runtime.Intrinsics;
+#endif
 using Xunit;
 using Xunit.Categories;
 
@@ -142,31 +145,180 @@ public class BitUtilsTests
         }
     }
 
-    /*
-    [Theory(DisplayName = "BitOps RotateRight UInt32")]
-    [InlineData(0b10000000_00000000_00000000_00000000u, int.MaxValue, 0b00000000_00000000_00000000_00000001u)] // % 32 = 31
-    [InlineData(0b00000000_00001000_00000000_00001010u, 3, 0b01000000_00000001_00000000_00000001u)]
-    [InlineData(0b00000000_00000100_00000000_00000101u, 2, 0b01000000_00000001_00000000_00000001u)]
-    [InlineData(0b01010101_01010101_01010101_01010101u, 1, 0b10101010_10101010_10101010_10101010u)]
-    [InlineData(0b01010101_11111111_01010101_01010101u, 0, 0b01010101_11111111_01010101_01010101u)]
-    [InlineData(0b10000000_00000000_00000000_00000000u, -1, 0b00000000_00000000_00000000_00000001u)]
-    [InlineData(0b00000000_00000000_00000000_00000001u, -2, 0b00000000_00000000_00000000_00000100u)]
-    [InlineData(0b01000000_00000000_00000000_00000000u, -3, 0b00000000_00000000_00000000_00000010u)]
-    [InlineData(0b01010101_11111111_01010101_01010101u, int.MinValue, 0b01010101_11111111_01010101_01010101u)] // % 32 = 0
-    public static void BitOps_RotateRight_uint(uint n, int offset, uint expected)
+#if NET6_0_OR_GREATER
+    [SkippableTheory(DisplayName = "BitOps RotateLeftVector128 All ChaCha20 Rotations")]
+    [InlineData(16)] // ChaCha20
+    [InlineData(12)] // ChaCha20
+    [InlineData(8)]  // ChaCha20
+    [InlineData(7)]  // ChaCha20
+    public static void BitOps_RotateLeftVector128_ChaCha20Rotations(int rotation)
     {
-        Assert.Equal(expected, BitUtils.RotateRight(n, offset));
+        Skip.IfNot(System.Runtime.Intrinsics.X86.Sse2.IsSupported, "SSE2 not supported on this platform");
+
+        var testValues = new uint[] { 0x12345678u, 0x87654321u, 0xAABBCCDDu, 0x55AA55AAu };
+        var vector = System.Runtime.Intrinsics.Vector128.Create(testValues[0], testValues[1], testValues[2], testValues[3]);
+
+        var result = BitUtils.RotateLeftVector128(vector, rotation);
+
+        // Verify each element matches scalar rotation
+        for (int i = 0; i < 4; i++)
+        {
+            var expected = BitUtils.RotateLeft(testValues[i], rotation);
+            Assert.Equal(expected, result.GetElement(i));
+        }
     }
 
-    [Fact(DisplayName = "BitOps RotateRight UInt64")]
-    public static void BitOps_RotateRight_ulong()
+    [SkippableTheory(DisplayName = "BitOps RotateLeftVector128 All Salsa20 Rotations")]
+    [InlineData(18)] // Salsa20
+    [InlineData(13)] // Salsa20
+    [InlineData(9)]  // Salsa20
+    public static void BitOps_RotateLeftVector128_Salsa20Rotations(int rotation)
     {
-        ulong value = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul;
-        Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul, BitUtils.RotateRight(value, 1));
-        Assert.Equal(0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul, BitUtils.RotateRight(value, 2));
-        Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul, BitUtils.RotateRight(value, 3));
-        Assert.Equal(value, BitUtils.RotateRight(value, int.MinValue)); // % 64 = 0
-        Assert.Equal(BitUtils.RotateLeft(value, 63), BitUtils.RotateRight(value, int.MaxValue)); // % 64 = 63
+        Skip.IfNot(System.Runtime.Intrinsics.X86.Sse2.IsSupported, "SSE2 not supported on this platform");
+
+        var testValues = new uint[] { 0xF0F0F0F0u, 0x0F0F0F0Fu, 0xFF00FF00u, 0x00FF00FFu };
+        var vector = System.Runtime.Intrinsics.Vector128.Create(testValues[0], testValues[1], testValues[2], testValues[3]);
+
+        var result = BitUtils.RotateLeftVector128(vector, rotation);
+
+        // Verify each element matches scalar rotation
+        for (int i = 0; i < 4; i++)
+        {
+            var expected = BitUtils.RotateLeft(testValues[i], rotation);
+            Assert.Equal(expected, result.GetElement(i));
+        }
     }
-    */
+
+    [SkippableFact(DisplayName = "BitOps RotateLeftVector128 Invalid Rotation Throws")]
+    public static void BitOps_RotateLeftVector128_InvalidRotation_Throws()
+    {
+        Skip.IfNot(System.Runtime.Intrinsics.X86.Sse2.IsSupported, "SSE2 not supported on this platform");
+
+        var vector = System.Runtime.Intrinsics.Vector128.Create(1u, 2u, 3u, 4u);
+
+        // Test unsupported rotation values
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftVector128(vector, 1));
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftVector128(vector, 5));
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftVector128(vector, 10));
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftVector128(vector, 32));
+    }
+
+    [SkippableTheory(DisplayName = "BitOps RotateLeftVector256 All ChaCha20 Rotations")]
+    [InlineData(16)] // ChaCha20
+    [InlineData(12)] // ChaCha20
+    [InlineData(8)]  // ChaCha20
+    [InlineData(7)]  // ChaCha20
+    public static void BitOps_RotateLeftVector256_ChaCha20Rotations(int rotation)
+    {
+        Skip.IfNot(System.Runtime.Intrinsics.X86.Avx2.IsSupported, "AVX2 not supported on this platform");
+
+        var testValues = new uint[] { 0x12345678u, 0x87654321u, 0xAABBCCDDu, 0x55AA55AAu,
+                                       0xF0F0F0F0u, 0x0F0F0F0Fu, 0xFF00FF00u, 0x00FF00FFu };
+        var vector = System.Runtime.Intrinsics.Vector256.Create(testValues[0], testValues[1], testValues[2], testValues[3],
+                                                                  testValues[4], testValues[5], testValues[6], testValues[7]);
+
+        var result = BitUtils.RotateLeftVector256(vector, rotation);
+
+        // Verify each element matches scalar rotation
+        for (int i = 0; i < 8; i++)
+        {
+            var expected = BitUtils.RotateLeft(testValues[i], rotation);
+            Assert.Equal(expected, result.GetElement(i));
+        }
+    }
+
+    [SkippableTheory(DisplayName = "BitOps RotateLeftVector256 All Salsa20 Rotations")]
+    [InlineData(18)] // Salsa20
+    [InlineData(13)] // Salsa20
+    [InlineData(9)]  // Salsa20
+    public static void BitOps_RotateLeftVector256_Salsa20Rotations(int rotation)
+    {
+        Skip.IfNot(System.Runtime.Intrinsics.X86.Avx2.IsSupported, "AVX2 not supported on this platform");
+
+        var testValues = new uint[] { 0x11111111u, 0x22222222u, 0x33333333u, 0x44444444u,
+                                       0x55555555u, 0x66666666u, 0x77777777u, 0x88888888u };
+        var vector = System.Runtime.Intrinsics.Vector256.Create(testValues[0], testValues[1], testValues[2], testValues[3],
+                                                                  testValues[4], testValues[5], testValues[6], testValues[7]);
+
+        var result = BitUtils.RotateLeftVector256(vector, rotation);
+
+        // Verify each element matches scalar rotation
+        for (int i = 0; i < 8; i++)
+        {
+            var expected = BitUtils.RotateLeft(testValues[i], rotation);
+            Assert.Equal(expected, result.GetElement(i));
+        }
+    }
+
+    [SkippableFact(DisplayName = "BitOps RotateLeftVector256 Invalid Rotation Throws")]
+    public static void BitOps_RotateLeftVector256_InvalidRotation_Throws()
+    {
+        Skip.IfNot(System.Runtime.Intrinsics.X86.Avx2.IsSupported, "AVX2 not supported on this platform");
+
+        var vector = System.Runtime.Intrinsics.Vector256.Create(1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u);
+
+        // Test unsupported rotation values
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftVector256(vector, 1));
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftVector256(vector, 5));
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftVector256(vector, 10));
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftVector256(vector, 32));
+    }
+
+    [SkippableTheory(DisplayName = "BitOps RotateLeftAdvSimd All ChaCha20 Rotations")]
+    [InlineData(16)] // ChaCha20
+    [InlineData(12)] // ChaCha20
+    [InlineData(8)]  // ChaCha20
+    [InlineData(7)]  // ChaCha20
+    public static void BitOps_RotateLeftAdvSimd_ChaCha20Rotations(int rotation)
+    {
+        Skip.IfNot(System.Runtime.Intrinsics.Arm.AdvSimd.IsSupported, "AdvSIMD not supported on this platform");
+
+        var testValues = new uint[] { 0x12345678u, 0x87654321u, 0xAABBCCDDu, 0x55AA55AAu };
+        var vector = System.Runtime.Intrinsics.Vector128.Create(testValues[0], testValues[1], testValues[2], testValues[3]);
+
+        var result = BitUtils.RotateLeftAdvSimd(vector, rotation);
+
+        // Verify each element matches scalar rotation
+        for (int i = 0; i < 4; i++)
+        {
+            var expected = BitUtils.RotateLeft(testValues[i], rotation);
+            Assert.Equal(expected, result.GetElement(i));
+        }
+    }
+
+    [SkippableTheory(DisplayName = "BitOps RotateLeftAdvSimd All Salsa20 Rotations")]
+    [InlineData(18)] // Salsa20
+    [InlineData(13)] // Salsa20
+    [InlineData(9)]  // Salsa20
+    public static void BitOps_RotateLeftAdvSimd_Salsa20Rotations(int rotation)
+    {
+        Skip.IfNot(System.Runtime.Intrinsics.Arm.AdvSimd.IsSupported, "AdvSIMD not supported on this platform");
+
+        var testValues = new uint[] { 0xF0F0F0F0u, 0x0F0F0F0Fu, 0xFF00FF00u, 0x00FF00FFu };
+        var vector = System.Runtime.Intrinsics.Vector128.Create(testValues[0], testValues[1], testValues[2], testValues[3]);
+
+        var result = BitUtils.RotateLeftAdvSimd(vector, rotation);
+
+        // Verify each element matches scalar rotation
+        for (int i = 0; i < 4; i++)
+        {
+            var expected = BitUtils.RotateLeft(testValues[i], rotation);
+            Assert.Equal(expected, result.GetElement(i));
+        }
+    }
+
+    [SkippableFact(DisplayName = "BitOps RotateLeftAdvSimd Invalid Rotation Throws")]
+    public static void BitOps_RotateLeftAdvSimd_InvalidRotation_Throws()
+    {
+        Skip.IfNot(System.Runtime.Intrinsics.Arm.AdvSimd.IsSupported, "AdvSIMD not supported on this platform");
+
+        var vector = System.Runtime.Intrinsics.Vector128.Create(1u, 2u, 3u, 4u);
+
+        // Test unsupported rotation values
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftAdvSimd(vector, 1));
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftAdvSimd(vector, 5));
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftAdvSimd(vector, 10));
+        Assert.Throws<ArgumentException>(() => BitUtils.RotateLeftAdvSimd(vector, 32));
+    }
+#endif
 }

--- a/test/NaCl.Core.Tests/ChaCha20Poly1305Test.cs
+++ b/test/NaCl.Core.Tests/ChaCha20Poly1305Test.cs
@@ -541,12 +541,13 @@ public class ChaCha20Poly1305Test(ITestOutputHelper output)
         errors.ShouldBe(0);
     }
 
-    private string GetWycheproofTestVector()
+    private static string GetWycheproofTestVector()
     {
         try
         {
             using var client = new HttpClient();
-            return client.GetStringAsync("https://github.com/google/wycheproof/raw/master/testvectors/chacha20_poly1305_test.json").Result;
+            // originally hosted at: https://github.com/google/wycheproof/raw/master/testvectors/chacha20_poly1305_test.json
+            return client.GetStringAsync("https://github.com/C2SP/wycheproof/raw/refs/heads/main/testvectors/chacha20_poly1305_test.json").Result;
         }
         catch (Exception)
         {

--- a/test/NaCl.Core.Tests/ChaCha20Poly1305Test.cs
+++ b/test/NaCl.Core.Tests/ChaCha20Poly1305Test.cs
@@ -645,11 +645,11 @@ public class ChaCha20Poly1305Test(ITestOutputHelper output)
         {
             using var client = new HttpClient();
             // originally hosted at: https://github.com/google/wycheproof/raw/master/testvectors/chacha20_poly1305_test.json
-            return client.GetStringAsync("https://github.com/C2SP/wycheproof/raw/refs/heads/main/testvectors/chacha20_poly1305_test.json").Result;
+            return client.GetStringAsync("https://github.com/C2SP/wycheproof/raw/refs/heads/main/testvectors_v1/chacha20_poly1305_test.json").Result;
         }
         catch (Exception)
         {
-            return File.ReadAllText(@"Vectors\chacha20_poly1305_test.json");
+            return File.ReadAllText(Path.Combine("Vectors", "chacha20_poly1305_test.json"));
         }
     }
 }

--- a/test/NaCl.Core.Tests/ChaCha20Poly1305Test.cs
+++ b/test/NaCl.Core.Tests/ChaCha20Poly1305Test.cs
@@ -639,6 +639,63 @@ public class ChaCha20Poly1305Test(ITestOutputHelper output)
         decrypted.ShouldBe(overBoundaryMessage);
     }
 
+    [Fact]
+    public void DisposeZerosKeyAndPreventsReuse()
+    {
+        // Arrange
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        var plaintext = Encoding.UTF8.GetBytes("Test message");
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        var aad = Array.Empty<byte>();
+
+        var aead = new NaCl.Core.ChaCha20Poly1305(key);
+
+        // Act - dispose the cipher
+        aead.Dispose();
+
+        // Assert - using after dispose should throw ObjectDisposedException
+        var act = () => aead.Encrypt(nonce, plaintext, ciphertext, tag, aad);
+        act.ShouldThrow<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void UsingStatementDisposesCorrectly()
+    {
+        // Arrange
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        var plaintext = Encoding.UTF8.GetBytes("Test message");
+        var ciphertext = new byte[plaintext.Length];
+        var decrypted = new byte[plaintext.Length];
+        var tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        var aad = Array.Empty<byte>();
+
+        // Act & Assert - using statement should work correctly
+        using (var aead = new NaCl.Core.ChaCha20Poly1305(key))
+        {
+            aead.Encrypt(nonce, plaintext, ciphertext, tag, aad);
+            aead.Decrypt(nonce, ciphertext, tag, decrypted, aad);
+            decrypted.ShouldBe(plaintext);
+        }
+    }
+
+    [Fact]
+    public void DoubleDisposeDoesNotThrow()
+    {
+        // Arrange
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        var aead = new NaCl.Core.ChaCha20Poly1305(key);
+
+        // Act & Assert - double dispose should not throw
+        aead.Dispose();
+        var act = () => aead.Dispose();
+        act.ShouldNotThrow();
+    }
+
     private static string GetWycheproofTestVector()
     {
         try

--- a/test/NaCl.Core.Tests/ChaCha20Poly1305Test.cs
+++ b/test/NaCl.Core.Tests/ChaCha20Poly1305Test.cs
@@ -541,6 +541,104 @@ public class ChaCha20Poly1305Test(ITestOutputHelper output)
         errors.ShouldBe(0);
     }
 
+    [Fact]
+    public void EncryptDecryptLargeBufferPooledMemoryTest()
+    {
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(nonce);
+
+        var aead = new NaCl.Core.ChaCha20Poly1305(key);
+
+        // Test with large AAD that exceeds StackallocThreshold (1KB)
+        var largeAad = new byte[2048]; // 2KB AAD
+        RandomNumberGenerator.Fill(largeAad);
+
+        var message = new byte[100];
+        RandomNumberGenerator.Fill(message);
+
+        var tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        var ciphertext = new byte[message.Length];
+        var decrypted = new byte[message.Length];
+
+        // This should trigger the pooled memory path for large buffers
+        aead.Encrypt(nonce, message, ciphertext, tag, largeAad);
+        aead.Decrypt(nonce, ciphertext, tag, decrypted, largeAad);
+
+        decrypted.ShouldBe(message);
+    }
+
+    [Fact]
+    public void EncryptDecryptLargeCiphertextPooledMemoryTest()
+    {
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(nonce);
+
+        var aead = new NaCl.Core.ChaCha20Poly1305(key);
+
+        // Test with large message that when padded exceeds StackallocThreshold
+        var largeMessage = new byte[2048]; // 2KB message
+        RandomNumberGenerator.Fill(largeMessage);
+
+        var aad = new byte[16];
+        RandomNumberGenerator.Fill(aad);
+
+        var tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        var ciphertext = new byte[largeMessage.Length];
+        var decrypted = new byte[largeMessage.Length];
+
+        // This should trigger the pooled memory path for large buffers
+        aead.Encrypt(nonce, largeMessage, ciphertext, tag, aad);
+        aead.Decrypt(nonce, ciphertext, tag, decrypted, aad);
+
+        decrypted.ShouldBe(largeMessage);
+    }
+
+    [Fact]
+    public void EncryptDecryptStackallocThresholdBoundaryTest()
+    {
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(nonce);
+
+        var aead = new NaCl.Core.ChaCha20Poly1305(key);
+
+        // Test exactly at the boundary (1024 bytes)
+        var boundaryMessage = new byte[1008]; // 1008 + 16 (padding) = 1024
+        RandomNumberGenerator.Fill(boundaryMessage);
+
+        var aad = Array.Empty<byte>();
+        var tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        var ciphertext = new byte[boundaryMessage.Length];
+        var decrypted = new byte[boundaryMessage.Length];
+
+        // This should use stackalloc (right at threshold)
+        aead.Encrypt(nonce, boundaryMessage, ciphertext, tag, aad);
+        aead.Decrypt(nonce, ciphertext, tag, decrypted, aad);
+
+        decrypted.ShouldBe(boundaryMessage);
+
+        // Test just over the boundary
+        var overBoundaryMessage = new byte[1009]; // 1009 + 16 (padding) = 1025
+        RandomNumberGenerator.Fill(overBoundaryMessage);
+
+        ciphertext = new byte[overBoundaryMessage.Length];
+        decrypted = new byte[overBoundaryMessage.Length];
+
+        // This should use pooled memory
+        aead.Encrypt(nonce, overBoundaryMessage, ciphertext, tag, aad);
+        aead.Decrypt(nonce, ciphertext, tag, decrypted, aad);
+
+        decrypted.ShouldBe(overBoundaryMessage);
+    }
+
     private static string GetWycheproofTestVector()
     {
         try

--- a/test/NaCl.Core.Tests/ChaCha20Tests.cs
+++ b/test/NaCl.Core.Tests/ChaCha20Tests.cs
@@ -487,4 +487,59 @@ public class ChaCha20Tests
 
         CryptoBytes.Combine(block0, block1).ShouldBe(expected);
     }
+
+    [Fact]
+    public void DisposeZerosKeyAndPreventsReuse()
+    {
+        // Arrange
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        var plaintext = Encoding.UTF8.GetBytes("Test message");
+        var ciphertext = new byte[plaintext.Length];
+
+        var cipher = new ChaCha20(key, 0);
+
+        // Act - dispose the cipher
+        cipher.Dispose();
+
+        // Assert - using after dispose should throw ObjectDisposedException
+        var act = () => cipher.Encrypt(plaintext, nonce, ciphertext);
+        act.ShouldThrow<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public void UsingStatementDisposesCorrectly()
+    {
+        // Arrange
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        var plaintext = Encoding.UTF8.GetBytes("Test message");
+        var ciphertext = new byte[plaintext.Length];
+        var decrypted = new byte[plaintext.Length];
+
+        // Act & Assert - using statement should work correctly
+        using (var cipher = new ChaCha20(key, 0))
+        {
+            cipher.Encrypt(plaintext, nonce, ciphertext);
+            cipher.Decrypt(ciphertext, nonce, decrypted);
+            decrypted.ShouldBe(plaintext);
+        }
+
+        // Cipher is now disposed (no way to verify from outside, but the pattern works)
+    }
+
+    [Fact]
+    public void DoubleDisposeDoesNotThrow()
+    {
+        // Arrange
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        var cipher = new ChaCha20(key, 0);
+
+        // Act & Assert - double dispose should not throw
+        cipher.Dispose();
+        var act = () => cipher.Dispose();
+        act.ShouldNotThrow();
+    }
 }

--- a/test/NaCl.Core.Tests/ChaCha20Tests.cs
+++ b/test/NaCl.Core.Tests/ChaCha20Tests.cs
@@ -331,6 +331,109 @@ public class ChaCha20Tests
     }
 
     [Fact]
+    public void ChaCha20VectorIntrinsicsConsistencyTest()
+    {
+        // Test to ensure all ChaCha20 implementations (scalar, SSSE3, AVX2, AdvSimd) produce identical results
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(nonce);
+
+        var cipher = new ChaCha20(key, 1);
+
+        // Test various block sizes that will exercise different code paths
+        var testSizes = new[] { 64, 128, 192, 256, 512, 1024, 2048 };
+
+        foreach (var size in testSizes)
+        {
+            var plaintext = new byte[size];
+            RandomNumberGenerator.Fill(plaintext);
+
+            var ciphertext1 = new byte[size];
+            var ciphertext2 = new byte[size];
+
+            // Encrypt twice - should produce identical results
+            cipher.Encrypt(plaintext, nonce, ciphertext1);
+            cipher.Encrypt(plaintext, nonce, ciphertext2);
+
+            ciphertext1.ShouldBe(ciphertext2, $"Ciphertexts should be identical for size {size}");
+
+            // Decrypt and verify
+            var decrypted = new byte[size];
+            cipher.Decrypt(ciphertext1, nonce, decrypted);
+            decrypted.ShouldBe(plaintext, $"Decryption should match plaintext for size {size}");
+        }
+    }
+
+    [Fact]
+    public void ChaCha20DualBlockProcessingTest()
+    {
+        // Test to exercise dual-block AVX2 processing path
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(nonce);
+
+        var cipher = new ChaCha20(key, 0);
+
+        // Use exactly 128 bytes (2 blocks) to trigger dual-block processing
+        var plaintext = new byte[128];
+        RandomNumberGenerator.Fill(plaintext);
+
+        var ciphertext = new byte[128];
+        cipher.Encrypt(plaintext, nonce, ciphertext);
+
+        // Verify by decrypting
+        var decrypted = new byte[128];
+        cipher.Decrypt(ciphertext, nonce, decrypted);
+        decrypted.ShouldBe(plaintext);
+
+        // Test with larger sizes that are multiples of block size
+        var largeSizes = new[] { 256, 512, 1024 };
+        foreach (var size in largeSizes)
+        {
+            var largePlaintext = new byte[size];
+            RandomNumberGenerator.Fill(largePlaintext);
+
+            var largeCiphertext = new byte[size];
+            cipher.Encrypt(largePlaintext, nonce, largeCiphertext);
+
+            var largeDecrypted = new byte[size];
+            cipher.Decrypt(largeCiphertext, nonce, largeDecrypted);
+            largeDecrypted.ShouldBe(largePlaintext, $"Dual-block processing failed for size {size}");
+        }
+    }
+
+    [Fact]
+    public void ChaCha20ProcessKeyStreamBlockTest()
+    {
+        // Test the ProcessKeyStreamBlock method which is used internally
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var nonce = new byte[ChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(nonce);
+
+        var cipher = new ChaCha20(key, 0);
+
+        // Test single block processing
+        var keyStreamBlock = new byte[64]; // ChaCha20 block size
+        cipher.ProcessKeyStreamBlock(nonce, 0, keyStreamBlock);
+
+        // The keystream should not be all zeros (very unlikely with random key/nonce)
+        keyStreamBlock.ShouldNotBe(new byte[64]);
+
+        // Test with different counter values
+        var keyStreamBlock2 = new byte[64];
+        cipher.ProcessKeyStreamBlock(nonce, 1, keyStreamBlock2);
+
+        // Different counter should produce different keystream
+        keyStreamBlock.ShouldNotBe(keyStreamBlock2);
+    }
+
+    [Fact]
     public void ChaCha20TestVectorTC8()
     {
         // TC8: key: 'All your base are belong to us!, IV: 'IETF2013'

--- a/test/NaCl.Core.Tests/NaCl.Core.Tests.csproj
+++ b/test/NaCl.Core.Tests/NaCl.Core.Tests.csproj
@@ -16,13 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup Label="Test Assets">
-    <Content Include="..\vectors\chacha20_poly1305_test.json" Link="Vectors\chacha20_poly1305_test.json">
+    <Content Include="..\vectors\chacha20_poly1305_test.json" Link="Vectors/chacha20_poly1305_test.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\vectors\xchacha20_poly1305_test.json" Link="Vectors\xchacha20_poly1305_test.json">
+    <Content Include="..\vectors\xchacha20_poly1305_test.json" Link="Vectors/xchacha20_poly1305_test.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\vectors\salsa20-256.64-verified.test-vectors" Link="Vectors\salsa20-256.64-verified.test-vectors">
+    <Content Include="..\vectors\salsa20-256.64-verified.test-vectors" Link="Vectors/salsa20-256.64-verified.test-vectors">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -44,7 +44,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/NaCl.Core.Tests/NaCl.Core.Tests.csproj
+++ b/test/NaCl.Core.Tests/NaCl.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -36,7 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.categories" Version="3.0.1" />
@@ -44,7 +44,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/NaCl.Core.Tests/NaCl.Core.Tests.csproj
+++ b/test/NaCl.Core.Tests/NaCl.Core.Tests.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageReference Include="xunit.categories" Version="3.0.1" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/NaCl.Core.Tests/Poly1305Test.cs
+++ b/test/NaCl.Core.Tests/Poly1305Test.cs
@@ -367,4 +367,126 @@ public class Poly1305Test
         // Assert
         mac.ShouldBe(CryptoBytes.FromHexString("13000000000000000000000000000000"));
     }
+
+    [Fact]
+    public void ComputeMacLargeDataTest()
+    {
+        // Test with data that will exercise different code paths including hardware intrinsics
+        var key = new byte[Poly1305.MAC_KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        // Test various sizes to ensure all intrinsics paths are tested
+        int[] testSizes = { 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192 };
+
+        foreach (var size in testSizes)
+        {
+            var data = new byte[size];
+            RandomNumberGenerator.Fill(data);
+
+            var mac1 = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+            var mac2 = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+
+            // Compute MAC using span-based method
+            Poly1305.ComputeMac(key, data, mac1);
+
+            // Compute MAC using array-based method
+            var mac3 = Poly1305.ComputeMac(key, data);
+
+            // All should produce the same result
+            mac1.ShouldBe(mac3);
+            
+            // Verify MAC works
+            Action act = () => Poly1305.VerifyMac(key, data, mac1);
+            act.ShouldNotThrow();
+        }
+    }
+
+    [Fact]
+    public void ComputeMacOptimizedPathsTest()
+    {
+        // Test to ensure optimized paths (scalar, SSE2, AVX2, AdvSimd) are covered
+        var key = CryptoBytes.FromHexString("85d6be7857556d337f4452fe42d506a8"
+                                           + "0103808afb0db2fd4abff6af4149f51b");
+
+        // Test with different data patterns that might trigger different optimizations
+        var testCases = new[]
+        {
+            new byte[0], // Empty data
+            new byte[1] { 0xFF }, // Single byte
+            new byte[15] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, // 15 bytes (partial block)
+            new byte[16] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, // Exactly 16 bytes
+            new byte[17] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                          0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, // 17 bytes
+            new byte[64], // 64 bytes (multiple of 16)
+            new byte[65], // 65 bytes (not multiple of 16)
+        };
+
+        foreach (var data in testCases)
+        {
+            if (data.Length > 0)
+                RandomNumberGenerator.Fill(data);
+
+            var mac = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+            Action act = () => Poly1305.ComputeMac(key, data, mac);
+            act.ShouldNotThrow();
+
+            // Verify the computed MAC
+            Action verifyAct = () => Poly1305.VerifyMac(key, data, mac);
+            verifyAct.ShouldNotThrow();
+        }
+    }
+
+    [Fact]
+    public void ComputeMacWithDifferentAlignmentsTest()
+    {
+        // Test different memory alignments to ensure intrinsics work correctly
+        var key = new byte[Poly1305.MAC_KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var baseData = new byte[1024];
+        RandomNumberGenerator.Fill(baseData);
+
+        // Test different offsets/alignments
+        for (int offset = 0; offset < 8; offset++)
+        {
+            var alignedData = new byte[512 - offset];
+            Array.Copy(baseData, offset, alignedData, 0, alignedData.Length);
+
+            var mac = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+            Action act = () => Poly1305.ComputeMac(key, alignedData, mac);
+            act.ShouldNotThrow();
+
+            // Verify the MAC
+            Action verifyAct = () => Poly1305.VerifyMac(key, alignedData, mac);
+            verifyAct.ShouldNotThrow();
+        }
+    }
+
+    [Fact]
+    public void ComputeMacConsistencyAcrossImplementationsTest()
+    {
+        // Ensure all implementations (scalar, SSE2, AVX2, AdvSimd) produce identical results
+        var key = new byte[Poly1305.MAC_KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var testSizes = new[] { 0, 1, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 257, 511, 512, 513, 1023, 1024 };
+
+        foreach (var size in testSizes)
+        {
+            var data = new byte[size];
+            if (size > 0)
+                RandomNumberGenerator.Fill(data);
+
+            var mac = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+            Poly1305.ComputeMac(key, data, mac);
+
+            // The result should be deterministic regardless of which optimized path is taken
+            var mac2 = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+            Poly1305.ComputeMac(key, data, mac2);
+
+            mac.ShouldBe(mac2, $"MACs should be identical for data size {size}");
+        }
+    }
 }

--- a/test/NaCl.Core.Tests/Salsa20Tests.cs
+++ b/test/NaCl.Core.Tests/Salsa20Tests.cs
@@ -289,7 +289,7 @@ public class Salsa20Tests(ITestOutputHelper output)
         }
         catch (Exception)
         {
-            return File.ReadAllText(@"Vectors\salsa20-256.64-verified.test-vectors");
+            return File.ReadAllText(Path.Combine("Vectors", "salsa20-256.64-verified.test-vectors"));
         }
     }
 

--- a/test/NaCl.Core.Tests/XChaCha20Poly1305Test.cs
+++ b/test/NaCl.Core.Tests/XChaCha20Poly1305Test.cs
@@ -596,11 +596,11 @@ public class XChaCha20Poly1305Test(ITestOutputHelper output)
         {
             using var client = new HttpClient();
             // originally hosted at: https://github.com/google/wycheproof/raw/master/testvectors/xchacha20_poly1305_test.json
-            return client.GetStringAsync("https://github.com/C2SP/wycheproof/raw/refs/heads/main/testvectors/xchacha20_poly1305_test.json").Result;
+            return client.GetStringAsync("https://github.com/C2SP/wycheproof/raw/refs/heads/main/testvectors_v1/xchacha20_poly1305_test.json").Result;
         }
         catch (Exception)
         {
-            return File.ReadAllText(@"Vectors\xchacha20_poly1305_test.json");
+            return File.ReadAllText(Path.Combine("Vectors", "xchacha20_poly1305_test.json"));
         }
     }
 }

--- a/test/NaCl.Core.Tests/XChaCha20Poly1305Test.cs
+++ b/test/NaCl.Core.Tests/XChaCha20Poly1305Test.cs
@@ -521,12 +521,13 @@ public class XChaCha20Poly1305Test(ITestOutputHelper output)
         errors.ShouldBe(0);
     }
 
-    private string GetWycheproofTestVector()
+    private static string GetWycheproofTestVector()
     {
         try
         {
             using var client = new HttpClient();
-            return client.GetStringAsync("https://github.com/google/wycheproof/raw/master/testvectors/xchacha20_poly1305_test.json").Result;
+            // originally hosted at: https://github.com/google/wycheproof/raw/master/testvectors/xchacha20_poly1305_test.json
+            return client.GetStringAsync("https://github.com/C2SP/wycheproof/raw/refs/heads/main/testvectors/xchacha20_poly1305_test.json").Result;
         }
         catch (Exception)
         {

--- a/test/NaCl.Core.Tests/XChaCha20Poly1305Test.cs
+++ b/test/NaCl.Core.Tests/XChaCha20Poly1305Test.cs
@@ -521,6 +521,75 @@ public class XChaCha20Poly1305Test(ITestOutputHelper output)
         errors.ShouldBe(0);
     }
 
+    [Fact]
+    public void EncryptDecryptLargeBufferPooledMemoryTest()
+    {
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var nonce = new byte[XChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(nonce);
+
+        var aead = new XChaCha20Poly1305(key);
+
+        // Test with large AAD that exceeds StackallocThreshold (1KB)
+        var largeAad = new byte[2048]; // 2KB AAD
+        RandomNumberGenerator.Fill(largeAad);
+
+        var message = new byte[100];
+        RandomNumberGenerator.Fill(message);
+
+        var tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        var ciphertext = new byte[message.Length];
+        var decrypted = new byte[message.Length];
+
+        // This should trigger the pooled memory path for large buffers
+        aead.Encrypt(nonce, message, ciphertext, tag, largeAad);
+        aead.Decrypt(nonce, ciphertext, tag, decrypted, largeAad);
+
+        decrypted.ShouldBe(message);
+    }
+
+    [Fact]
+    public void EncryptDecryptStackallocThresholdBoundaryTest()
+    {
+        var key = new byte[Snuffle.KEY_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(key);
+
+        var nonce = new byte[XChaCha20.NONCE_SIZE_IN_BYTES];
+        RandomNumberGenerator.Fill(nonce);
+
+        var aead = new XChaCha20Poly1305(key);
+
+        // Test exactly at the boundary (1024 bytes)
+        var boundaryMessage = new byte[1008]; // 1008 + 16 (padding) = 1024
+        RandomNumberGenerator.Fill(boundaryMessage);
+
+        var aad = Array.Empty<byte>();
+        var tag = new byte[Poly1305.MAC_TAG_SIZE_IN_BYTES];
+        var ciphertext = new byte[boundaryMessage.Length];
+        var decrypted = new byte[boundaryMessage.Length];
+
+        // This should use stackalloc (right at threshold)
+        aead.Encrypt(nonce, boundaryMessage, ciphertext, tag, aad);
+        aead.Decrypt(nonce, ciphertext, tag, decrypted, aad);
+
+        decrypted.ShouldBe(boundaryMessage);
+
+        // Test just over the boundary
+        var overBoundaryMessage = new byte[1009]; // 1009 + 16 (padding) = 1025
+        RandomNumberGenerator.Fill(overBoundaryMessage);
+
+        ciphertext = new byte[overBoundaryMessage.Length];
+        decrypted = new byte[overBoundaryMessage.Length];
+
+        // This should use pooled memory
+        aead.Encrypt(nonce, overBoundaryMessage, ciphertext, tag, aad);
+        aead.Decrypt(nonce, ciphertext, tag, decrypted, aad);
+
+        decrypted.ShouldBe(overBoundaryMessage);
+    }
+
     private static string GetWycheproofTestVector()
     {
         try


### PR DESCRIPTION
First take on .NET Hardware Intrinsics:

- Support AVX2 and SSE3 in `ChaCha20Base.ShuffleState`
- Support AVX2 and SSE3 in `ChaCha20Base.QuarterRound`

Implemented proper SSE2 and AdvSIMD optimizations for Poly1305:

-  `ComputeMacSse2` - Uses SSE2 Vector128 intrinsics for:
    -  SIMD loads for key and data blocks
    -  SIMD store for the final 16-byte tag output
    -  The polynomial multiplication remains scalar due to data dependencies inherent to Poly1305's design
-  `ComputeMacAdvSimd` - Uses ARM AdvSIMD Vector128 intrinsics with the same optimization pattern for ARM64 platforms (like macOS)
-  Updated `ComputeMac` dispatch to check for SSE2 and AdvSIMD support after AVX2


Pending:

- Support AVX2 and SSE3 and ARM AdvSIMD in `Salsa20Base`

